### PR TITLE
Uninit and `FixedVec`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,8 @@ introducing new dependencies and *should* contain no non-optional dependency.
 
 ## Usage
 
+As a global allocator for `alloc`:
+
 ```rust
 use static_alloc::Slab;
 
@@ -39,6 +41,22 @@ fn main() {
 
     println!("{:x?}", &buffer[..]);
 }
+```
+
+As local memory pools for fixed capacity `FixedVec`:
+
+```rust
+use static_alloc::{FixedVec, Uninit};
+use core::mem::MaybeUninit;
+
+let mut pool: MaybeUninit<[u8; 1024]> = MaybeUninit::uninit();
+let mut vec = FixedVec::from_available(Uninit::from(&mut pool));
+
+let mut num = 0;
+// Push a mutable reference, not `Copy` nor `Clone`!
+vec.push(&mut num);
+
+# drop(vec);
 ```
 
 ## Additional

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -190,7 +190,7 @@ mod tests {
         const CAPACITY: usize = 30;
 
         let mut allocation: MaybeUninit<[Foo; CAPACITY]> = MaybeUninit::uninit();
-        let mut vec = FixedVec::from_available(Uninit::from_maybe_uninit(&mut allocation));
+        let mut vec = FixedVec::from_available((&mut allocation).into());
 
         assert_eq!(vec.capacity(), CAPACITY);
         assert_eq!(vec.len(), 0);
@@ -223,7 +223,7 @@ mod tests {
 
 
         let mut allocation: MaybeUninit<[HasDrop; COUNT]> = MaybeUninit::uninit();
-        let mut vec = FixedVec::from_available(Uninit::from_maybe_uninit(&mut allocation));
+        let mut vec = FixedVec::from_available((&mut allocation).into());
 
         for i in 0..COUNT {
             assert!(vec.push(HasDrop(i)).is_ok());
@@ -236,9 +236,7 @@ mod tests {
     #[test]
     fn zst() {
         struct Zst;
-
         let mut vec = FixedVec::<Zst>::new(Uninit::empty());
-
         assert_eq!(vec.capacity(), usize::max_value());
     }
 
@@ -246,7 +244,8 @@ mod tests {
     fn split_and_shrink() {
         // Zeroed because we want to test the contents.
         let mut allocation: MaybeUninit<[u16; 8]> = MaybeUninit::zeroed();
-        let mut aligned = Uninit::from_maybe_uninit(&mut allocation).as_memory();
+
+        let mut aligned = Uninit::from(&mut allocation).as_memory();
         let _ = aligned.split_at_byte(15);
 
         let mut vec = FixedVec::from_available(aligned);

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -1,0 +1,89 @@
+use core::{ptr, slice};
+use crate::uninit::Uninit;
+
+pub struct FixedVec<'a, T> {
+    uninit: Uninit<'a, [T]>,
+    length: usize,
+}
+
+impl<T> FixedVec<'_, T> {
+    pub fn as_slice(&self) -> &[T] {
+        unsafe {
+            // SAFETY: length is the number of initialized elements.
+            slice::from_raw_parts(self.uninit.as_begin_ptr(), self.length)
+        }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        unsafe {
+            // SAFETY:
+            // * length is the number of initialized elements.
+            // * unaliased since we take ourselves by `mut` and `uninit` does the rest.
+            slice::from_raw_parts_mut(self.uninit.as_begin_ptr(), self.length)
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    pub fn capacity(&mut self) -> usize {
+        self.uninit.capacity()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    pub fn push(&mut self, val: T) -> Result<(), T> {
+        if self.length == usize::max_value() {
+            return Err(val);
+        }
+
+        let init = match self.head_tail_mut().1.split_first() {
+            Ok((init, _)) => init,
+            Err(_) => return Err(val),
+        };
+
+        init.init(val);
+        self.length += 1;
+
+        Ok(())
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        if self.length == 0 {
+            return None;
+        }
+
+        let (_, last) = self.head_tail_mut().0.split_last().ok().unwrap();
+        let val = unsafe {
+            // SAFETY: initialized and no reference of any kind exists to it.
+            ptr::read(last.as_ptr())
+        };
+        self.length -= 1;
+        Some(val)
+    }
+
+    fn head_tail_mut(&mut self) -> (Uninit<'_, [T]>, Uninit<'_, [T]>) {
+        // This must always be possible. `self.length` is nevery greater than the capacity.
+        self.uninit.borrow_mut().split_at(self.length).ok().unwrap()
+    }
+}
+
+impl<'a, T> FixedVec<'a, T> {
+    pub fn new(uninit: Uninit<'a, [T]>) -> Self {
+        FixedVec {
+            uninit,
+            length: 0,
+        }
+    }
+}
+
+impl<T> Drop for FixedVec<'_, T> {
+    fn drop(&mut self) {
+        unsafe {
+            ptr::drop_in_place(self.as_mut_slice())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,12 @@
 #![no_std]
 
 pub mod slab;
-mod uninit;
-mod vec;
+pub mod uninit;
+pub mod fixed_vec;
 
-use uninit::Uninit;
-
-pub use crate::slab::Slab;
+pub use fixed_vec::FixedVec;
+pub use uninit::Uninit;
+pub use slab::Slab;
 
 // Can't use the macro-call itself within the `doc` attribute. So force it to eval it as part of
 // the macro invocation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,25 @@
 //! }
 //! ```
 //!
+//! `FixedVec` without forced `Clone` or `Copy` semantics:
+//!
+//! ```rust
+//! use static_alloc::{FixedVec, Uninit};
+//! use core::mem::MaybeUninit;
+//!
+//! let mut pool: MaybeUninit<[u8; 1024]> = MaybeUninit::uninit();
+//! let mut vec = FixedVec::from_available(Uninit::from(&mut pool));
+//!
+//! let mut num = 0;
+//! // Push a mutable reference, not `Copy` nor `Clone`!
+//! vec.push(&mut num);
+//!
+//! *vec.pop().unwrap() = 4;
+//! drop(vec);
+//!
+//! assert_eq!(num, 4);
+//! ```
+//!
 //! ## Why the name?
 //!
 //! This crates makes it safe to define a *static* object and to then use its memory to *allocate*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,10 @@
 #![no_std]
 
 pub mod slab;
+mod uninit;
+mod vec;
+
+use uninit::Uninit;
 
 pub use crate::slab::Slab;
 

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -79,7 +79,7 @@ impl Uninit<'_, ()> {
 
     /// Split so that the second part fits the layout.
     pub fn split_layout(self, layout: Layout) -> Result<(Self, Self), Self> {
-        let align = self.ptr.as_ptr().align_offset(layout.align());
+        let align = self.ptr.cast::<u8>().as_ptr().align_offset(layout.align());
         let aligned_len = self.len.checked_sub(align).and_then(|len| len.checked_sub(layout.size()));
 
         if aligned_len.is_none() {

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -591,6 +591,18 @@ impl<'a, T: ?Sized> UninitView<'a, T> {
     }
 }
 
+impl<'a, T> From<&'a mut mem::MaybeUninit<T>> for Uninit<'a, T> {
+    fn from(mem: &'a mut mem::MaybeUninit<T>) -> Self {
+        Uninit::from_maybe_uninit(mem)
+    }
+}
+
+impl<'a, T> From<&'a mem::MaybeUninit<T>> for UninitView<'a, T> {
+    fn from(mem: &'a mem::MaybeUninit<T>) -> Self {
+        UninitView::from_maybe_uninit(mem)
+    }
+}
+
 impl<T: ?Sized> fmt::Debug for Uninit<'_, T> {
    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
        f.debug_tuple("Uninit")

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -1,0 +1,82 @@
+use core::{mem, ptr};
+use core::marker::PhantomData;
+
+/// Points to an uninitialized place but would otherwise be a valid reference.
+pub struct Uninit<'a, T> {
+    ptr: ptr::NonNull<T>,
+    len: usize,
+    lifetime: PhantomData<&'a mut T>,
+}
+
+impl Uninit<'_, ()> {
+    pub unsafe fn from_memory(ptr: ptr::NonNull<()>, len: usize) -> Self {
+        Uninit {
+            ptr,
+            len,
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Uninit<'a, T> {
+    pub fn cast<U>(self) -> Result<Uninit<'a, U>, Self> {
+        if self.ptr.as_ptr().align_offset(mem::align_of::<U>()) != 0 {
+            return Err(self);
+        }
+
+        if self.len < mem::size_of::<T>() {
+            return Err(self);
+        }
+
+        Ok(Uninit {
+            ptr: self.ptr.cast(),
+            len: self.len,
+            lifetime: PhantomData,
+        })
+    }
+
+    /// Initialize the place and return a reference to the value.
+    pub fn init(self, val: T) -> &'a mut T {
+        let ptr = self.as_ptr();
+        unsafe {
+            ptr::write(ptr, val);
+            &mut *ptr
+        }
+    }
+
+    /// Acquires the underlying *mut pointer.
+    pub fn as_ptr(self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    /// Acquires the underlying pointer as a `NonNull`.
+    pub fn as_non_null(self) -> ptr::NonNull<T> {
+        self.ptr
+    }
+
+    /// Dereferences the content.
+    ///
+    /// The resulting lifetime is bound to self so this behaves "as if" it were actually an
+    /// instance of T that is getting borrowed. If a longer lifetime is needed, use `into_ref`.
+    pub unsafe fn as_ref(&self) -> &T {
+        self.ptr.as_ref()
+    }
+
+    /// Mutably dereferences the content.
+    ///
+    /// The resulting lifetime is bound to self so this behaves "as if" it were actually an
+    /// instance of T that is getting borrowed. If a longer lifetime is needed, use `into_mut`.
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        self.ptr.as_mut()
+    }
+
+    /// Turn this into a reference to the content.
+    pub unsafe fn into_ref(self) -> &'a T {
+        &*self.as_ptr()
+    }
+
+    /// Turn this into a mutable reference to the content.
+    pub unsafe fn into_mut(self) -> &'a mut T {
+        &mut *self.as_ptr()
+    }
+}

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -70,7 +70,7 @@ impl Uninit<'_, ()> {
         // In particular, no pointer within or one-past-the-end is null.
         let next_base = unsafe { ptr::NonNull::new_unchecked(base.add(at)) };
         let next_len = self.len - at;
-        self.len -= at;
+        self.len = at;
 
         // SAFETY:
         // * unaliased because we just clear it.

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -1,12 +1,29 @@
-use core::{mem, ptr};
+use core::{mem, ptr, slice};
 use core::alloc::Layout;
 use core::marker::PhantomData;
 
 /// Points to an uninitialized place but would otherwise be a valid reference.
+///
+/// Makes it possible to deal with uninitialized allocations without requiring an `unsafe` block
+/// initializing them and offering a much safer interface for partial initialization and layout
+/// calculations than raw pointers.
 #[derive(Debug)]
-pub struct Uninit<'a, T> {
+pub struct Uninit<'a, T: ?Sized> {
+    /// Pointer to the start of the region.
+    ///
+    /// Note that `len` is always at least as large as the (minimum) size of `T`. Furthermore, the
+    /// pointer is always correctly aligned to a `T`.
     ptr: ptr::NonNull<T>,
+
+    /// The actual length *in bytes*.
+    ///
+    /// May be larger than required.
     len: usize,
+
+    /// Virtual lifetime to make this behave more similar to references.
+    ///
+    /// This borrows structures that hand out `Uninit` allocations. Note that this struct is not
+    /// `Clone` since it encapsulates an unaliased range within an allocation.
     lifetime: PhantomData<&'a mut T>,
 }
 
@@ -14,8 +31,15 @@ impl Uninit<'_, ()> {
     /// Create a uninit pointer from raw memory.
     ///
     /// ## Safety
-    /// A valid, unaliased allocation must exist at the pointer with length at least `len`. It need
-    /// *not* be initialized.
+    /// A valid allocation must exist at the pointer with length at least `len`. There must be *no*
+    /// references aliasing the memory location, and it must be valid to write uninitialized bytes
+    /// into arbitrary locations of the region.
+    ///
+    /// In particular, it is **UB** to create this from a reference to a variable of a type for
+    /// which a completely uninitialized content is not valid. The standard type for avoiding the
+    /// UB is `core::mem::MaybeUninit`.
+    ///
+    /// When in doubt, refactor code such that utilization of `from_maybe_uninit` is possible.
     pub unsafe fn from_memory(ptr: ptr::NonNull<()>, len: usize) -> Self {
         Uninit {
             ptr,
@@ -44,7 +68,7 @@ impl Uninit<'_, ()> {
     }
 
     /// Split so that the second part fits the layout.
-    pub fn split_align(self, layout: Layout) -> Result<(Self, Self), Self> {
+    pub fn split_layout(self, layout: Layout) -> Result<(Self, Self), Self> {
         let align = self.ptr.as_ptr().align_offset(layout.align());
         let aligned_len = self.len.checked_sub(align).and_then(|len| len.checked_sub(layout.size()));
 
@@ -55,6 +79,22 @@ impl Uninit<'_, ()> {
         let (front, aligned) = self.split_at(align)?;
         assert!(aligned.fits(layout));
         Ok((front, aligned))
+    }
+}
+
+impl<'a> Uninit<'a, ()> {
+    /// Split so that the tail is aligned and valid for a `U`.
+    pub fn split_cast<U>(self) -> Result<(Self, Uninit<'a, U>), Self> {
+        let (this, split) = self.split_layout(Layout::new::<U>())?;
+        let cast = split.cast::<U>().ok().unwrap();
+        Ok((this, cast))
+    }
+
+    pub fn split_slice<U>(self) -> Result<(Self, Uninit<'a, [U]>), Self> {
+        let layout = Layout::for_value::<[U]>(&[]);
+        let (this, split) = self.split_layout(layout)?;
+        let cast = split.cast_slice::<U>().ok().unwrap();
+        Ok((this, cast))
     }
 }
 
@@ -71,16 +111,26 @@ impl<T> Uninit<'_, T> {
     pub fn invent_for_zst() -> Self {
         assert_eq!(mem::size_of::<T>(), 0, "Invented ZST uninit invoked with non-ZST");
         let dangling = ptr::NonNull::<T>::dangling();
+        // SAFETY:
+        // * unaliased for all lifetimes
+        // * writing zero uninitialized bytes is well-defined
         let raw = unsafe { Uninit::from_memory(dangling.cast(), 0) };
         raw.cast().unwrap()
-    }
-
-    pub fn len(&self) -> usize {
-        self.len
     }
 }
 
 impl<'a, T> Uninit<'a, T> {
+    pub fn from_maybe_uninit(mem: &'a mut mem::MaybeUninit<T>) -> Self {
+        let ptr = ptr::NonNull::new(mem.as_mut_ptr()).unwrap();
+        let raw = unsafe {
+            // SAFETY:
+            // * unaliased as we had a mutable reference
+            // * can write uninitialized bytes as much as we want
+            Uninit::from_memory(ptr.cast(), mem::size_of_val(mem))
+        };
+        raw.cast().ok().unwrap()
+    }
+
     pub fn cast<U>(self) -> Result<Uninit<'a, U>, Self> {
         if !self.fits(Layout::new::<U>()) {
             return Err(self);
@@ -93,22 +143,84 @@ impl<'a, T> Uninit<'a, T> {
         })
     }
 
+    pub fn cast_slice<U>(self) -> Result<Uninit<'a, [U]>, Self> {
+        let empty = Layout::for_value::<[U]>(&[]);
+
+        if !self.fits(empty) {
+            return Err(self)
+        }
+
+        let slice = unsafe {
+            // SAFETY: correctly aligned and empty.
+            slice::from_raw_parts_mut(self.ptr.cast().as_ptr(), 0)
+        };
+
+        Ok(Uninit {
+            ptr: slice.into(),
+            len: self.len,
+            lifetime: PhantomData,
+        })
+    }
+
+    /// Split off the tail that is not required to hold an instance of `T`.
+    pub fn shrink_to_fit(self) -> (Self, Uninit<'a, ()>) {
+        // `()` fits every uninit
+        let deinit = self.cast::<()>().ok().unwrap();
+        // UNWRAP: our own layout fits `T`
+        let (minimal, tail) = deinit.split_at(mem::size_of::<T>()).ok().unwrap();
+        // UNWRAP: the alignment didn't change, and size is still large enough
+        let restored = minimal.cast().ok().unwrap();
+        (restored, tail)
+    }
+
     /// Initialize the place and return a reference to the value.
     pub fn init(self, val: T) -> &'a mut T {
         let ptr = self.as_ptr();
         unsafe {
+            // SAFETY:
+            // * can only create instances where layout of `T` 'fits'
+            // * valid for lifetime `'a` (as per unsafe constructor).
+            // * unaliased for lifetime `'a` (as per unsafe constructor).
             ptr::write(ptr, val);
             &mut *ptr
         }
     }
+}
+
+impl<'a, T> Uninit<'a, [T]> {
+    pub fn as_begin_ptr(&self) -> *mut T {
+        self.ptr.as_ptr() as *mut T
+    }
+
+    pub fn len(&self) -> usize {
+        self.size() / mem::size_of::<T>()
+    }
+}
+
+impl<'a, T: ?Sized> Uninit<'a, T> {
+    /// Borrow the `Uninit` region for a shorter duration.
+    ///
+    /// This is the equivalent of `&mut *mut_ref`.
+    pub fn borrow(&mut self) -> Uninit<'_, T> {
+        Uninit {
+            ptr: self.ptr,
+            len: self.len,
+            lifetime: PhantomData,
+        }
+    }
+
+    /// Get the byte size of the total allocation.
+    pub fn size(&self) -> usize {
+        self.len
+    }
 
     /// Acquires the underlying *mut pointer.
-    pub fn as_ptr(self) -> *mut T {
+    pub fn as_ptr(&self) -> *mut T {
         self.ptr.as_ptr()
     }
 
     /// Acquires the underlying pointer as a `NonNull`.
-    pub fn as_non_null(self) -> ptr::NonNull<T> {
+    pub fn as_non_null(&self) -> ptr::NonNull<T> {
         self.ptr
     }
 

--- a/src/uninit.rs
+++ b/src/uninit.rs
@@ -42,15 +42,17 @@ use core::marker::PhantomData;
 /// let uninit = Uninit::from_maybe_uninit(&mut alloc);
 ///
 /// // Now use the first `u32` for a counter:
-/// let (counter, tail) = uninit.cast().unwrap().split_to_fit();
+/// let mut counter = uninit.cast().unwrap();
+/// let mut tail = counter.split_to_fit();
 /// let counter: &mut u32 = counter.init(0);
 ///
 /// // And some more for a few `u64`.
 /// // Note that these are not trivially aligned, but `Uninit` does that for us.
-/// let (_, tail) = tail.split_cast().unwrap();
-/// let (values, tail) = tail.split_to_fit();
+/// let mut values = tail.split_cast().unwrap();
+/// // No more use, so don't bother with `split_to_fit` and just `init`.
 /// let values: &mut [u64; 2] = values.init([0xdead, 0xbeef]);
 /// ```
+#[must_use = "This is a pointer-like type that has no effect on its own. Use `init` to insert a value."]
 pub struct Uninit<'a, T: ?Sized> {
     /// Pointer to the start of the region.
     ///
@@ -78,6 +80,7 @@ pub struct Uninit<'a, T: ?Sized> {
 /// the `Uninit` and manually managing pointers to the region.
 ///
 /// [`Uninit`]: ./struct.Uninit.html
+#[must_use = "This is a pointer-like type that has no effect on its own."]
 pub struct UninitView<'a, T: ?Sized>(
     /// The region. The pointer in it must never be dereferenced mutably.
     Uninit<'a, T>,
@@ -104,42 +107,22 @@ impl Uninit<'_, ()> {
         }
     }
 
-    /// Split the uninit slice at a byte boundary.
-    ///
-    /// Return `Ok` if the location is in-bounds and `Err` if it is out of bounds.
-    pub fn split_at_byte(mut self, at: usize) -> Result<(Self, Self), Self> {
-        if self.len < at {
-            return Err(self)
-        }
-
-        let base = self.ptr.cast::<u8>().as_ptr();
-        // SAFETY: by `from_memory`, all offsets `< len` are within the allocation.
-        // In particular, no pointer within or one-past-the-end is null.
-        let next_base = unsafe { ptr::NonNull::new_unchecked(base.add(at)) };
-        let next_len = self.len - at;
-        self.len = at;
-
-        // SAFETY:
-        // * unaliased because we just clear it.
-        // * within one allocation, namely the one we are in.
-        let other = unsafe { Self::from_memory(next_base.cast(), next_len) };
-        Ok((self, other))
-    }
-
     /// Split so that the second part fits the layout.
     ///
     /// Return `Ok` if this is possible in-bounds and `Err` if it is not.
-    pub fn split_layout(self, layout: Layout) -> Result<(Self, Self), Self> {
+    pub fn split_layout(&mut self, layout: Layout) -> Option<Self> {
         let align = self.ptr.cast::<u8>().as_ptr().align_offset(layout.align());
-        let aligned_len = self.len.checked_sub(align).and_then(|len| len.checked_sub(layout.size()));
+        let aligned_len = self.len
+            .checked_sub(align)
+            .and_then(|len| len.checked_sub(layout.size()));
 
         if aligned_len.is_none() {
-            return Err(self)
+            return None;
         }
 
-        let (front, aligned) = self.split_at_byte(align)?;
+        let aligned = self.split_at_byte(align)?;
         assert!(aligned.fits(layout));
-        Ok((front, aligned))
+        Some(aligned)
     }
 }
 
@@ -157,10 +140,10 @@ impl<'a> Uninit<'a, ()> {
     /// Return `Ok` if this is possible in-bounds (aligned and enough room for at least one `U`)
     /// and `Err` if it is not. The first tuple element is the `Uninit` pointing to the skipped
     /// memory.
-    pub fn split_cast<U>(self) -> Result<(Self, Uninit<'a, U>), Self> {
-        let (this, split) = self.split_layout(Layout::new::<U>())?;
+    pub fn split_cast<U>(&mut self) -> Option<Uninit<'a, U>> {
+        let split = self.split_layout(Layout::new::<U>())?;
         let cast = split.cast::<U>().unwrap();
-        Ok((this, cast))
+        Some(cast)
     }
 
     /// Split so that the tail is aligned for a slice `[U]`.
@@ -171,11 +154,11 @@ impl<'a> Uninit<'a, ()> {
     /// The length of the slice is the arbitrary amount that fits into the tail of the allocation.
     /// Note that the length always fulfills the safety requirements for `slice::from_raw_parts`
     /// since the `Uninit` must be contained in a single allocation.
-    pub fn split_slice<U>(self) -> Result<(Self, Uninit<'a, [U]>), Self> {
+    pub fn split_slice<U>(&mut self) -> Option<Uninit<'a, [U]>> {
         let layout = Layout::for_value::<[U]>(&[]);
-        let (this, split) = self.split_layout(layout)?;
+        let split = self.split_layout(layout)?;
         let cast = split.cast_slice::<U>().unwrap();
-        Ok((this, cast))
+        Some(cast)
     }
 }
 
@@ -211,6 +194,28 @@ impl<'a, T> Uninit<'a, T> {
             Uninit::from_memory(ptr.cast(), mem::size_of_val(mem))
         };
         raw.cast().unwrap()
+    }
+
+    /// Split the uninit slice at a byte boundary.
+    ///
+    /// Return `Ok` if the location is in-bounds and `Err` if it is out of bounds.
+    pub fn split_at_byte(&mut self, at: usize) -> Option<Uninit<'a, ()>> {
+        if self.len < at || at < mem::size_of::<T>() {
+            return None;
+        }
+
+        let base = self.ptr.cast::<u8>().as_ptr();
+        // SAFETY: by `from_memory`, all offsets `< len` are within the allocation.
+        // In particular, no pointer within or one-past-the-end is null.
+        let next_base = unsafe { ptr::NonNull::new_unchecked(base.add(at)) };
+        let next_len = self.len - at;
+        self.len = at;
+
+        // SAFETY:
+        // * unaliased because we just clear it.
+        // * within one allocation, namely the one we are in.
+        let other = unsafe { Uninit::from_memory(next_base.cast(), next_len) };
+        Some(other)
     }
 
     /// Try to cast to an `Uninit` for another type.
@@ -259,13 +264,10 @@ impl<'a, T> Uninit<'a, T> {
     }
 
     /// Split off the tail that is not required for holding an instance of `T`.
-    pub fn split_to_fit(self) -> (Self, Uninit<'a, ()>) {
-        let deinit = Uninit::decast(self);
-        // UNWRAP: our own layout fits `T`
-        let (minimal, tail) = deinit.split_at_byte(mem::size_of::<T>()).unwrap();
-        // UNWRAP: the alignment didn't change, and size is still large enough
-        let restored = minimal.cast().unwrap();
-        (restored, tail)
+    ///
+    /// This operation is idempotent.
+    pub fn split_to_fit(&mut self) -> Uninit<'a, ()> {
+        self.split_at_byte(mem::size_of::<T>()).unwrap()
     }
 
     /// Initialize the place and return a reference to the value.
@@ -302,39 +304,58 @@ impl<'a, T> Uninit<'a, [T]> {
     /// Split the slice at an index.
     ///
     /// This is the pointer equivalent of `slice::split_at`.
-    pub fn split_at(self, at: usize) -> Result<(Self, Self), Self> {
-        let byte = match at.checked_mul(mem::size_of::<T>()) {
-            None => return Err(self),
-            Some(byte) if byte > self.len => return Err(self),
+    pub fn split_at(&mut self, at: usize) -> Option<Self> {
+        let bytes = match at.checked_mul(mem::size_of::<T>()) {
+            None => return None,
+            Some(byte) if byte > self.len => return None,
             Some(byte) => byte,
         };
 
-        let deinit = Uninit::decast(self);
-        let (head, tail) = deinit.split_at_byte(byte).unwrap();
-        let head = head.cast_slice().unwrap();
-        let tail = tail.cast_slice().unwrap();
+        let next_len = self.len - bytes;
+        self.len = bytes;
+        // SAFETY: was previously in bounds.
+        let next_base = unsafe { self.as_begin_ptr().add(at) };
+        // SAFETY: 0 length (aliasing) but really in bounds as well.
+        let slice = unsafe { slice::from_raw_parts_mut(next_base, 0) };
 
-        Ok((head, tail))
+        Some(Uninit {
+            ptr: slice.into(),
+            len: next_len,
+            lifetime: self.lifetime,
+        })
+    }
+
+    /// Get the trailing bytes behind the slice.
+    ///
+    /// The underlying allocation need not be a multiple of the slice element size which may leave
+    /// unusable bytes. This splits these unusable bytes into an untyped `Uninit` which can be
+    /// reused arbitrarily.
+    ///
+    /// This operation is idempotent.
+    pub fn shrink_to_fit(&mut self) -> Uninit<'a, ()> {
+        Uninit::decast(self.split_at(self.capacity()).unwrap())
     }
 
     /// Split the first element from the slice.
     ///
     /// This is the pointer equivalent of `slice::split_first`.
-    pub fn split_first(self) -> Result<(Uninit<'a, T>, Self), Self> {
-        self.split_at(1)
-            // If it is a valid slice of length 1 it is a valid `T`.
-            .map(|(init, tail)| (Uninit::decast(init).cast().unwrap(), tail))
+    pub fn split_first(&mut self) -> Option<Uninit<'a, T>> {
+        let mut part = self.split_at(1)?;
+        // Now we are the first part, but we wanted the first to be split off.
+        mem::swap(self, &mut part);
+        // If it is a valid slice of length 1 it is a valid `T`.
+        Some(Uninit::decast(part).cast().unwrap())
     }
 
     /// Split the last element from the slice.
     ///
     /// This is the pointer equivalent of `slice::split_last`.
-    pub fn split_last(self) -> Result<(Self, Uninit<'a, T>), Self> {
+    pub fn split_last(&mut self) -> Option<Uninit<'a, T>> {
         // Explicitely wrap here: If capacity is 0 then `0 < size_of::<T> ` and the split will fail.
         let split = self.capacity().wrapping_sub(1);
-        self.split_at(split)
-            // If it is a valid slice of length 1 it is a valid `T`.
-            .map(|(head, init)| (head, Uninit::decast(init).cast().unwrap()))
+        let part = self.split_at(split)?;
+        // If it is a valid slice of length 1 it is a valid `T`.
+        Some(Uninit::decast(part).cast().unwrap())
     }
 }
 
@@ -405,41 +426,25 @@ impl<'a, T: ?Sized> Uninit<'a, T> {
     }
 }
 impl UninitView<'_, ()> {
-    /// Split the uninit view at a byte boundary.
-    ///
-    /// See [`Uninit::split_at_byte`] for more details.
-    ///
-    /// [`Uninit::split_at_byte`]: ./struct.Uninit.html#method.split_at_byte
-    pub fn split_at_byte(self, at: usize) -> Result<(Self, Self), Self> {
-        let (head, tail) = self.0.split_at_byte(at).map_err(UninitView)?;
-        Ok((UninitView(head), UninitView(tail)))
-    }
-
     /// Split so that the second part fits the layout.
     ///
     /// See [`Uninit::split_layout`] for more details.
     ///
     /// [`Uninit::split_layout`]: ./struct.Uninit.html#method.split_layout
-    pub fn split_layout(self, layout: Layout) -> Result<(Self, Self), Self> {
-        let (head, tail) = self.0.split_layout(layout).map_err(UninitView)?;
-        Ok((UninitView(head), UninitView(tail)))
+    pub fn split_layout(&mut self, layout: Layout) -> Option<Self> {
+        self.0.split_layout(layout).map(UninitView)
     }
 }
 
 impl<'a> UninitView<'a, ()> {
     /// Split so that the tail is aligned and valid for a `U`.
-    pub fn split_cast<U>(self) -> Result<(Self, UninitView<'a, U>), Self> {
-        let (this, split) = self.split_layout(Layout::new::<U>())?;
-        let cast = split.cast::<U>().unwrap();
-        Ok((this, cast))
+    pub fn split_cast<U>(&mut self) -> Option<UninitView<'a, U>> {
+        self.0.split_cast().map(UninitView)
     }
 
     /// Split so that the tail is aligned for a slice `[U]`.
-    pub fn split_slice<U>(self) -> Result<(Self, UninitView<'a, [U]>), Self> {
-        let layout = Layout::for_value::<[U]>(&[]);
-        let (this, split) = self.split_layout(layout)?;
-        let cast = split.cast_slice::<U>().unwrap();
-        Ok((this, cast))
+    pub fn split_slice<U>(&mut self) -> Option<UninitView<'a, [U]>> {
+        self.0.split_slice().map(UninitView)
     }
 }
 
@@ -454,6 +459,15 @@ impl<T> UninitView<'_, T> {
 }
 
 impl<'a, T> UninitView<'a, T> {
+    /// Split the uninit view at a byte boundary.
+    ///
+    /// See [`Uninit::split_at_byte`] for more details.
+    ///
+    /// [`Uninit::split_at_byte`]: ./struct.Uninit.html#method.split_at_byte
+    pub fn split_at_byte(&mut self, at: usize) -> Option<UninitView<'a, ()>> {
+        self.0.split_at_byte(at).map(UninitView)
+    }
+
     /// Create an view to the inner bytes of a `MaybeUninit`.
     ///
     /// This is hardly useful on its own but since `UninitView` mirrors the traversal methods of
@@ -485,9 +499,8 @@ impl<'a, T> UninitView<'a, T> {
     }
 
     /// Split off the tail that is not required for holding an instance of `T`.
-    pub fn split_to_fit(self) -> (Self, UninitView<'a, ()>) {
-        let (head, tail) = self.0.split_to_fit();
-        (UninitView(head), UninitView(tail))
+    pub fn split_to_fit(&mut self) -> UninitView<'a, ()> {
+        UninitView(self.0.split_to_fit())
     }
 }
 
@@ -503,21 +516,18 @@ impl<'a, T> UninitView<'a, [T]> {
     }
 
     /// Split the slice at an index.
-    pub fn split_at(self, at: usize) -> Result<(Self, Self), Self> {
-        let (head, tail) = self.0.split_at(at).map_err(UninitView)?;
-        Ok((UninitView(head), UninitView(tail)))
+    pub fn split_at(&mut self, at: usize) -> Option<Self> {
+        self.0.split_at(at).map(UninitView)
     }
 
     /// Split the first element from the slice.
-    pub fn split_first(self) -> Result<(UninitView<'a, T>, Self), Self> {
-        let (head, tail) = self.0.split_first().map_err(UninitView)?;
-        Ok((UninitView(head), UninitView(tail)))
+    pub fn split_first(&mut self) -> Option<UninitView<'a, T>> {
+        self.0.split_first().map(UninitView)
     }
 
     /// Split the last element from the slice.
-    pub fn split_last(self) -> Result<(Self, UninitView<'a, T>), Self> {
-        let (head, tail) = self.0.split_last().map_err(UninitView)?;
-        Ok((UninitView(head), UninitView(tail)))
+    pub fn split_last(&mut self) -> Option<UninitView<'a, T>> {
+        self.0.split_last().map(UninitView)
     }
 }
 


### PR DESCRIPTION
A true `FixedVec` that does not require additional `Clone` or `Copy` bounds. It does however not own its internal memory as a `MaybeUninit`. But this allows it to get its memory supplied from a stack-local shared *allocator* (i.e. dynamically partitioned).