### PR TITLE
Add explicit recursive list Box test

### DIFF
--- a/tests/box.rs
+++ b/tests/box.rs
@@ -1,0 +1,28 @@
+use static_alloc::boxed::Box;
+use static_alloc::Slab;
+
+#[test]
+fn recursive() {
+    enum List<'a, T> {
+        Nil,
+        Cons(T, Box<'a, Self>),
+    }
+
+    impl<T> List<'_, T> {
+        pub fn len(&self) -> usize {
+            match self {
+                List::Nil => 0,
+                List::Cons(_, tail) => 1 + tail.len(),
+            }
+        }
+    }
+
+    let slab: Slab<[usize; 32]> = Slab::uninit();
+    let mut list = slab.boxed(List::Nil).unwrap();
+
+    for i in 0usize..8 {
+        list = slab.boxed(List::Cons(i, list)).unwrap();
+    }
+
+    assert_eq!(list.len(), 8);
+}


### PR DESCRIPTION
A non-complete version was previously 'hidden' in the documentation. An explicit integration tests for it can't hurt.