### PR TITLE
Fix unsafety in fill

### DIFF
--- a/tests/alloc/vec.rs
+++ b/tests/alloc/vec.rs
@@ -1,7 +1,7 @@
 use static_alloc::Slab;
 
 #[global_allocator]
-static A: Slab<[u8; 1 << 16]> = Slab::uninit();
+static A: Slab<[u8; 1 << 20]> = Slab::uninit();
 
 #[test]
 fn ok_vec() {


### PR DESCRIPTION
It would write an instance to uninitialized part of the vector with an
assignment, dropping an uninitialized instance in the process.

Introduced a test to ensure this doesn't happen again in the same way.