### PR TITLE
Double ended drain

### DIFF
--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -244,7 +244,7 @@ mod tests {
         let boxed: Box<'static, _> = SLAB.boxed(&local).unwrap();
         // Check that we can leak with appropriate lifetime.
         let _: & mut _ = Box::leak(boxed);
-
-        drop(local);
+        // local needs to be live for the time before the box is leaked
+        let _ = local;
     }
 }

--- a/tests/fixed_vec.rs
+++ b/tests/fixed_vec.rs
@@ -125,7 +125,7 @@ fn truncations() {
 }
 
 #[test]
-fn drain() {
+fn drain_forward() {
     const COUNT: usize = 16;
     let mut memory: [MaybeUninit<usize>; COUNT] = [MaybeUninit::uninit(); COUNT];
     let mut vec = FixedVec::new((&mut memory[..]).into());
@@ -136,6 +136,40 @@ fn drain() {
     drain.as_mut_slice()[0] = 0xFF;
     assert_eq!(drain.next(), Some(0xFF));
     assert!((1..8).eq(&mut drain));
+    drop(drain);
+    assert!((8..COUNT).eq(vec.iter().copied()));
+}
+
+#[test]
+fn drain_reverse() {
+    const COUNT: usize = 16;
+    let mut memory: [MaybeUninit<usize>; COUNT] = [MaybeUninit::uninit(); COUNT];
+    let mut vec = FixedVec::new((&mut memory[..]).into());
+
+    assert_eq!(vec.fill(0..COUNT).len(), 0);
+    let mut drain = vec.drain(..8);
+    assert_eq!(drain.as_slice(), [0, 1, 2, 3, 4, 5, 6, 7]);
+    drain.as_mut_slice()[7] = 0xFF;
+    assert_eq!(drain.next_back(), Some(0xFF));
+    assert!((0..7).eq(&mut drain));
+    drop(drain);
+    assert!((8..COUNT).eq(vec.iter().copied()));
+}
+
+#[test]
+fn drain_double_ended() {
+    const COUNT: usize = 16;
+    let mut memory: [MaybeUninit<usize>; COUNT] = [MaybeUninit::uninit(); COUNT];
+    let mut vec = FixedVec::new((&mut memory[..]).into());
+
+    assert_eq!(vec.fill(0..COUNT).len(), 0);
+    let mut drain = vec.drain(..8);
+    assert_eq!(drain.as_slice(), [0, 1, 2, 3, 4, 5, 6, 7]);
+    drain.as_mut_slice()[0] = 0xFF;
+    drain.as_mut_slice()[7] = 0xFF;
+    assert_eq!(drain.next(), Some(0xFF));
+    assert_eq!(drain.next_back(), Some(0xFF));
+    assert!((1..7).eq(&mut drain));
     drop(drain);
     assert!((8..COUNT).eq(vec.iter().copied()));
 }

--- a/tests/rc.rs
+++ b/tests/rc.rs
@@ -31,7 +31,6 @@ fn reference_juggling() {
         }
     }
 
-
     let memory: Slab<[u8; 1024]> = Slab::uninit();
     let alloc = memory.get_layout(rc::Rc::<HotPotato>::layout()).unwrap();
     let ptr = alloc.uninit.as_non_null();
@@ -101,6 +100,7 @@ fn downgrade_upgrade() {
 
 #[test]
 fn compares() {
+    use std::cmp::PartialEq;
     let memory: Slab<[u8; 1024]> = Slab::uninit();
 
     let zero = memory.rc(0usize).unwrap();
@@ -108,7 +108,7 @@ fn compares() {
 
     assert_eq!(zero, zero);
     assert_eq!(one, one);
-    assert!(!(zero != zero));
+    assert!(!PartialEq::ne(&zero, &zero));
     assert_ne!(zero, one);
 
     assert!(zero < one);


### PR DESCRIPTION
This implements `DoubleEndedIterator` for `FixedVec`'s `Drain` struct. Also fixes a few clippy error-level lints. 