### PR TITLE
Improve the iterator compatibility of FixedVec

### DIFF
--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -3,7 +3,7 @@
 //! [See `FixedVec` for the main information][`FixedVec`].
 //!
 //! [`FixedVec`]: struct.FixedVec.html
-use core::{borrow, cmp, hash, ops, ptr, slice};
+use core::{borrow, cmp, hash, iter, ops, ptr, slice};
 use crate::uninit::Uninit;
 
 /// A `Vec`-like structure that does not manage its allocation.
@@ -618,7 +618,7 @@ impl<T> Iterator for Drain<'_, T> {
 
 impl<T> DoubleEndedIterator for Drain<'_, T> {
     fn next_back(&mut self) -> Option<T> {
-        if self.count == self.end {
+        if self.len() == 0 {
             return None;
         }
         let t = unsafe {
@@ -629,6 +629,14 @@ impl<T> DoubleEndedIterator for Drain<'_, T> {
         Some(t)
     }
 }
+
+impl<T> ExactSizeIterator for Drain<'_, T> {
+    fn len(&self) -> usize {
+        self.end - self.count
+    }
+}
+
+impl<T> iter::FusedIterator for Drain<'_, T> { }
 
 impl<T> Drop for Drain<'_, T> {
     fn drop(&mut self) {

--- a/tests/fixed_vec.rs
+++ b/tests/fixed_vec.rs
@@ -165,10 +165,13 @@ fn drain_double_ended() {
     assert_eq!(vec.fill(0..COUNT).len(), 0);
     let mut drain = vec.drain(..8);
     assert_eq!(drain.as_slice(), [0, 1, 2, 3, 4, 5, 6, 7]);
+    assert_eq!(drain.len(), 8);
     drain.as_mut_slice()[0] = 0xFF;
     drain.as_mut_slice()[7] = 0xFF;
     assert_eq!(drain.next(), Some(0xFF));
+    assert_eq!(drain.len(), 7);
     assert_eq!(drain.next_back(), Some(0xFF));
+    assert_eq!(drain.len(), 6);
     assert!((1..7).eq(&mut drain));
     drop(drain);
     assert!((8..COUNT).eq(vec.iter().copied()));


### PR DESCRIPTION
Ensure that `Drain` implements some hint traits defined by the standard library. This is most useful with specialization (hence, within the standard library itself) as hints to opportunistic optimizations such as pre-allocation but might have other uses as well.

Also provides `Extend` for `FixedVec`, which is just like `fill` but drops the iterator after consuming it or filling itself to full capacity.