### PR TITLE
Rename generic Invariant to AllocTime

### DIFF
--- a/alloc-traits/src/global.rs
+++ b/alloc-traits/src/global.rs
@@ -1,5 +1,5 @@
 use core::ptr::NonNull;
-use super::{Allocation, Invariant, NonZeroLayout};
+use super::{Allocation, AllocTime, NonZeroLayout};
 
 pub struct Global;
 
@@ -53,6 +53,6 @@ fn from_global_ptr<'any>(ptr: *mut u8, layout: NonZeroLayout) -> Option<Allocati
     Some(Allocation {
         ptr,
         layout: layout,
-        lifetime: Invariant::default(),
+        lifetime: AllocTime::default(),
     })
 }

--- a/alloc-traits/src/lib.rs
+++ b/alloc-traits/src/lib.rs
@@ -29,9 +29,13 @@ pub use layout::{Layout, NonZeroLayout};
 
 /// A marker struct denoting a lifetime that is not simply coercible to another.
 #[derive(Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Invariant<'lt> {
+pub struct AllocTime<'lt> {
     marker: PhantomData<&'lt fn(&'lt ())>,
 }
+
+/// A marker struct denoting a lifetime that is not simply coercible to another.
+#[deprecated = "Use the new name 'AllocTime' instead"]
+pub type Invariant<'lt> = AllocTime<'lt>;
 
 /// An allocation valid for a particular lifetime.
 ///
@@ -44,7 +48,7 @@ pub struct Allocation<'alloc> {
     /// The allocated layout.
     pub layout: NonZeroLayout,
     /// The lifetime of the allocation.
-    pub lifetime: Invariant<'alloc>,
+    pub lifetime: AllocTime<'alloc>,
 }
 
 /// An allocator providing memory regions valid for a particular lifetime.
@@ -98,8 +102,8 @@ pub unsafe trait LocalAlloc<'alloc> {
     }
 }
 
-impl fmt::Debug for Invariant<'_> {
+impl fmt::Debug for AllocTime<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.pad("Invariant")
+        f.pad("AllocTime")
     }
 }

--- a/static-alloc/src/bump.rs
+++ b/static-alloc/src/bump.rs
@@ -10,7 +10,7 @@ use core::mem::{self, MaybeUninit};
 use core::ptr::{NonNull, null_mut};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use alloc_traits::{Invariant, LocalAlloc, NonZeroLayout};
+use alloc_traits::{AllocTime, LocalAlloc, NonZeroLayout};
 
 /// Allocator drawing from an inner, statically sized memory resource.
 ///
@@ -238,7 +238,7 @@ pub struct Allocation<'a, T=u8> {
     pub ptr: NonNull<T>,
 
     /// The lifetime of the allocation.
-    pub lifetime: Invariant<'a>,
+    pub lifetime: AllocTime<'a>,
 
     /// The observed amount of consumed bytes after the allocation.
     pub level: Level,
@@ -502,7 +502,7 @@ impl<T> Bump<T> {
 
         Ok(Allocation {
             ptr: NonNull::new(aligned).unwrap(),
-            lifetime: Invariant::default(),
+            lifetime: AllocTime::default(),
             level: Level(new_consumed),
         })
     }
@@ -626,7 +626,7 @@ impl<T> Bump<T> {
 
         Allocation {
             ptr: NonNull::from(alloc).cast(),
-            lifetime: Invariant::default(),
+            lifetime: AllocTime::default(),
             level: self.level(),
         }
     }
@@ -717,7 +717,7 @@ unsafe impl<'alloc, T> LocalAlloc<'alloc> for Bump<T> {
         Some(alloc_traits::Allocation {
             ptr: raw_alloc.ptr,
             layout: layout,
-            lifetime: Invariant::default(),
+            lifetime: AllocTime::default(),
         })
     }
 


### PR DESCRIPTION
This makes sure it is named after its function and not after is
mechanism that is internally used to implement that functionality. Note
that there are not unsafe invariants upheld by it, it merely serves to
prevent mistakes.