### PR TITLE
Add an assign wrapper implementing Fill

### DIFF
--- a/fill/src/assign.rs
+++ b/fill/src/assign.rs
@@ -1,0 +1,39 @@
+/// Assign to a sequence with Fill semantics.
+///
+/// This struct is crated through the [`IntoIteratorExt::assign`] method. See its documentation for
+/// details.
+pub struct Assign<I> {
+    inner: I,
+}
+
+impl<'item, T: 'item, I> Assign<I>
+where
+    I: ExactSizeIterator + Iterator<Item=&'item mut T>,
+{
+    pub(crate) fn new(inner: I) -> Self {
+        Assign { inner }
+    }
+}
+
+
+impl<'item, T: 'item, I>
+    crate::Fill<T>
+for 
+    Assign<I>
+where
+    I: ExactSizeIterator + Iterator<Item=&'item mut T>,
+{
+    fn fill<J>(&mut self, iter: J)
+        where J: IntoIterator<Item=T>,
+    {
+        let mut iter = iter.into_iter();
+        // Do not use `zip` to control the exact calls to `next`.
+        while self.inner.len() != 0 {
+            if let Some(item) = iter.next() {
+                *self.inner.next().unwrap() = item;
+            } else {
+                break
+            }
+        }
+    }
+}

--- a/fill/src/assign.rs
+++ b/fill/src/assign.rs
@@ -2,6 +2,8 @@
 ///
 /// This struct is crated through the [`IntoIteratorExt::assign`] method. See its documentation for
 /// details.
+///
+/// [`IntoIteratorExt::assign`]: trait.IntoIteratorExt.html#method.assign
 pub struct Assign<I> {
     inner: I,
 }
@@ -30,7 +32,7 @@ where
         // Do not use `zip` to control the exact calls to `next`.
         while self.inner.len() != 0 {
             if let Some(item) = iter.next() {
-                *self.inner.next().unwrap() = item;
+                *self.inner.next().expect("Fill: Exact size iterator unexpectedly empty.") = item;
             } else {
                 break
             }

--- a/fill/src/lib.rs
+++ b/fill/src/lib.rs
@@ -43,9 +43,23 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+mod assign;
 mod fill;
 
-pub use fill::Fill;
+pub use crate::assign::Assign;
+pub use crate::fill::Fill;
+
+pub trait IntoIteratorExt: IntoIterator {
+    fn assign<'item, T: 'item>(self) -> Assign<Self::IntoIter>
+    where
+        Self: Sized + IntoIterator<Item=&'item mut T>,
+        Self::IntoIter: ExactSizeIterator,
+    {
+        Assign::<Self::IntoIter>::new(self.into_iter())
+    }
+}
+
+impl<T: IntoIterator> IntoIteratorExt for T { }
 
 // Can't use the macro-call itself within the `doc` attribute. So force it to eval it as part of
 // the macro invocation.

--- a/fill/src/lib.rs
+++ b/fill/src/lib.rs
@@ -49,7 +49,33 @@ mod fill;
 pub use crate::assign::Assign;
 pub use crate::fill::Fill;
 
+/// Adapt generic iterable structs into interaction with `Fill`.
+///
+/// This is an extension traits that provides generic convenience adaptors.
 pub trait IntoIteratorExt: IntoIterator {
+    /// An adaptor that 'fills' the sequence by assigning to its referenced elements.
+    ///
+    /// One can view the remaining items that have yet to be iterated over as free slots that need
+    /// to be initialized. The assigned-from iterator is only polled if there is a free slot and,
+    /// conversely, the assigned-to iterator is only advanced if there is an actual element to
+    /// write. If the assigned-to iterator misrepresented its capacity then the fill process
+    /// panics.
+    ///
+    /// This requires the guarantee of being able to advance the iterator without calling `next`.
+    /// Requiring the underlying iterator to implement `ExactSizeIterator` allows implementing this
+    /// check.
+    ///
+    /// # Examples
+    ///
+    /// This overwrites an arbitrarily sized memory region with a repeating pattern.
+    ///
+    /// ```rust
+    /// use fill::{Fill, IntoIteratorExt};
+    ///
+    /// fn init_with_pattern(mem: &mut [u8]) {
+    ///     mem.assign().fill((0..10).cycle());
+    /// }
+    /// ```
     fn assign<'item, T: 'item>(self) -> Assign<Self::IntoIter>
     where
         Self: Sized + IntoIterator<Item=&'item mut T>,

--- a/fill/tests/core.rs
+++ b/fill/tests/core.rs
@@ -1,4 +1,4 @@
-use fill::Fill;
+use fill::{Fill, IntoIteratorExt};
 
 #[test]
 fn slice() {
@@ -43,4 +43,13 @@ fn result() {
     assert_eq!(unfilled.len(), 1);
 
     assert_eq!(memory, [0, 1, 0, 0]);
+}
+
+#[test]
+fn assign() {
+    let zero: &mut [u8] = &mut [0u8; 4];
+    let ones = [1u8; 2];
+
+    zero.assign().fill(ones.iter().copied());
+    assert_eq!(zero, [1, 1, 0, 0]);
 }


### PR DESCRIPTION
Open questions:

* Name bikeshedding. Alternatives ottomh:
  - `assign_from`, in line with `clone_from`.
  - `assign_dst`, would allow a corresponding reverse `assign_src`

* What about an implementation of `Fill<&mut T>` which swaps the elements? Should it be under a different name? If so, which? Should this influence the naming of this struct?

* Is it technically better to have the extension trait on `IntoIterator` or on `Iterator`?