### PR TITLE
Unsize with a trick

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,8 +36,15 @@ release_task:
     image: rust:latest
   script: ./release_checks without-alloc
 
+miri_alloc_traits_task:
+  container:
+    image: rustlang/rust:nightly
+  script:
+    - rustup component add --toolchain nightly miri
+    - cd alloc-traits
+    - rustup run nightly cargo-miri miri test
+
 miri_without_alloc_task:
-  only_if: $CIRRUS_BRANCH =~ 'release-without-alloc.*'
   container:
     image: rustlang/rust:nightly
   script:

--- a/alloc-traits/Cargo.toml
+++ b/alloc-traits/Cargo.toml
@@ -15,5 +15,8 @@ name = "alloc_traits"
 
 [dependencies]
 
+[build-dependencies]
+autocfg = "1"
+
 [package.metadata.docs.rs]
 all-features = true

--- a/alloc-traits/build.rs
+++ b/alloc-traits/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let ac = autocfg::new();
+    ac.emit_rustc_version(1, 51);
+}

--- a/alloc-traits/src/lib.rs
+++ b/alloc-traits/src/lib.rs
@@ -28,4 +28,4 @@ pub use crate::layout::{Layout, NonZeroLayout};
 pub use crate::local::{AllocTime, Allocation, LocalAlloc};
 #[allow(deprecated)]
 pub use crate::local::Invariant;
-pub use crate::unsize::{CoerceUnsize, CoerciblePtr};
+pub use crate::unsize::{Coercion, CoerceUnsize, CoerceUnsizeExt};

--- a/alloc-traits/src/lib.rs
+++ b/alloc-traits/src/lib.rs
@@ -28,4 +28,4 @@ pub use crate::layout::{Layout, NonZeroLayout};
 pub use crate::local::{AllocTime, Allocation, LocalAlloc};
 #[allow(deprecated)]
 pub use crate::local::Invariant;
-pub use crate::unsize::{Coercion, CoerceUnsize, CoerceUnsizeExt};
+pub use crate::unsize::{Coercion, CoerceUnsize, CoerciblePtr};

--- a/alloc-traits/src/lib.rs
+++ b/alloc-traits/src/lib.rs
@@ -15,15 +15,17 @@
 //! [`static-alloc`]: https://crates.io/crates/static-alloc
 //! [`without-alloc`]: https://crates.io/crates/without-alloc
 
-// Copyright 2019 Andreas Molzer
+// Copyright 2019-2021 Andreas Molzer
 #![no_std]
 #![deny(missing_docs)]
 
 mod layout;
 mod local;
+mod unsize;
 pub mod util;
 
 pub use crate::layout::{Layout, NonZeroLayout};
 pub use crate::local::{AllocTime, Allocation, LocalAlloc};
 #[allow(deprecated)]
 pub use crate::local::Invariant;
+pub use crate::unsize::{CoerceUnsize, CoerciblePtr};

--- a/alloc-traits/src/unsize.rs
+++ b/alloc-traits/src/unsize.rs
@@ -192,6 +192,27 @@ coerce_to_dyn_trait!(
     fn to_display() -> core::fmt::Display
 );
 
+impl<T, const N: usize> Coercion<[T; N], [T]> {
+    /// Create a coercer that unsizes an array to a slice.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use alloc_traits::{Coercion, CoerceUnsize};
+    /// use core::fmt::Display;
+    ///
+    /// fn generic<T>(ptr: &[T; 2]) -> &[T] {
+    ///     ptr.unsize(Coercion::to_slice())
+    /// }
+    /// ```
+    pub fn to_slice() -> Self {
+        fn coerce<T, const N: usize>(
+            ptr: *const [T; N]
+        ) -> *const [T] { ptr }
+        Coercion { coerce }
+    }
+}
+
 /// Add unsizing methods to pointer-like types.
 ///
 /// # Safety

--- a/alloc-traits/src/unsize.rs
+++ b/alloc-traits/src/unsize.rs
@@ -1,0 +1,147 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+mod impls {
+    use core::ptr::NonNull;
+    use super::{CoerceUnsize, unsize_with};
+
+    unsafe impl<'lt, T, U: ?Sized + 'lt> CoerceUnsize<U> for &'lt T {
+        type Pointee = T;
+        type Output = &'lt U;
+        unsafe fn unsize_with<F: Fn(&T) -> &U>(self, with: F) -> Self::Output {
+            &*unsize_with(NonNull::from(self), with).as_ptr()
+        }
+    }
+
+    unsafe impl<'lt, T, U: ?Sized + 'lt> CoerceUnsize<U> for &'lt mut T {
+        type Pointee = T;
+        type Output = &'lt mut U;
+        unsafe fn unsize_with<F: Fn(&T) -> &U>(self, with: F) -> Self::Output {
+            &mut *unsize_with(NonNull::from(self), with).as_ptr()
+        }
+    }
+
+    /* TODO: this actually does _not_ seem self-evident.
+     * Quite the opposite, the requirements on `with` might be stronger. But consider that we only
+     * pass a shared reference so maybe my worries are over nothing.
+    impl<Ptr, U> CoerceUnsize<U> for core::pin::Pin<Ptr>
+    where
+        Ptr: CoerceUnsize<U>
+    {
+        type Output = core::pin::Pin<Ptr::Output>;
+        unsafe fn unsize_with(self, with: impl Fn(&Self) -> &U) -> Self::Output {
+            self.into_inner_unchecked()
+        }
+    }
+    */
+
+    unsafe impl<T, U: ?Sized> CoerceUnsize<U> for core::ptr::NonNull<T> {
+        type Pointee = T;
+        type Output = NonNull<U>;
+        unsafe fn unsize_with<F: Fn(&T) -> &U>(self, with: F) -> Self::Output {
+            unsize_with(NonNull::from(self), with)
+        }
+    }
+}
+
+/// Enables the unsizing of a sized pointer.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct CoerciblePtr<T> {
+    ptr: NonNull<T>,
+}
+
+/// Add unsizing methods to pointer-like types.
+pub unsafe trait CoerceUnsize<U: ?Sized>: Sized {
+    /// The type we point to.
+    /// This influences which kinds of unsizing are possible.
+    type Pointee;
+    /// The output type when unsizing the pointee to `U`.
+    type Output;
+    /// Convert a pointer, as if with unsize coercion.
+    ///
+    /// See [`CoerciblePtr::unsize_with`][unsize_with] for details.
+    ///
+    /// [unsize_with]: struct.CoerciblePtr.html#method.unsize_with
+    unsafe fn unsize_with<F: Fn(&Self::Pointee) -> &U>(self, with: F) -> Self::Output;
+}
+
+impl<T> CoerciblePtr<T> {
+    /// Get the contained pointer as a `NonNull`.
+    pub fn get(self) -> NonNull<T> {
+        self.ptr
+    }
+
+    /// Get the contained pointer.
+    pub fn as_ptr(&self) -> *mut T {
+        self.ptr.as_ptr()
+    }
+
+    /// Convert a pointer, as if with unsize coercion.
+    ///
+    /// The result pointer will have the same provenance information as the argument `ptr`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that it is sound to dereference the argument and convert it into a
+    /// reference. This also, very slightly, relies on some of Rust's internal layout but it will
+    /// assert that they actually hold. If this sounds too risky, do not use this method. The caller
+    /// must also guarantee that `with` will only execute a coercion and _not_ change the pointer
+    /// itself.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    ///
+    /// ```
+    pub unsafe fn unsize_with<U: ?Sized>(self, with: impl Fn(&T) -> &U) -> NonNull<U> {
+        unsize_with(self.ptr, with)
+    }
+}
+
+/// Convert a pointer, as if with unsize coercion.
+///
+/// The result pointer will have the same provenance information as the argument `ptr`.
+///
+/// # Safety
+///
+/// The caller must guarantee that it is sound to dereference the argument and convert it into a
+/// reference. This also, very slightly, relies on some of Rust's internal layout but it will
+/// assert that they actually hold. If this sounds too risky, do not use this method. The caller
+/// must also guarantee that `with` will only execute a coercion and _not_ change the pointer
+/// itself.
+#[allow(unused_unsafe)] // Err on the side of caution.
+unsafe fn unsize_with<T, U: ?Sized>(
+    ptr: NonNull<T>,
+    with: impl Fn(&T) -> &U,
+) -> NonNull<U> {
+    let raw = ptr.as_ptr();
+
+    let mut raw_unsized = {
+        // Safety: caller upholds this directly.
+        let temp_reference = unsafe { &*raw };
+        with(temp_reference) as *const U
+    };
+
+    debug_assert_eq!(Layout::for_value(&raw_unsized), Layout::new::<[usize; 2]>(),
+        "Unexpected layout of unsized pointer.");
+    debug_assert_eq!(raw_unsized as *const u8 as usize, raw as usize,
+        "Unsize coercion seemingly changed the pointer base");
+
+    let ptr_slot = &mut raw_unsized as *mut *const U as *mut *const u8;
+    // Safety: Not totally clear as it relies on the standard library implementation of pointers.
+    // The layout is usually valid for such a write (we've asserted that above) and all pointers
+    // are larger and at least as aligned as a single pointer to bytes.
+    // It could be that this invalidates the representation of `raw_unsized` but all currently
+    // pointers store their tag _behind_ the base pointer.
+    //
+    // There is an `unsafe`, unstable method (#75091) with the same effect and implementation.
+    //
+    // According to the `ptr::set_ptr_value` method we change provenance back to the `raw` pointer.
+    // This can be used since we haven't used any pointer from which it was derived. This
+    // invalidates the access tags of `temp_reference` and the original `raw_unsized` value but
+    // both will no longer be used.
+    unsafe { ptr_slot.write(raw as *const u8) };
+
+    // Safety: the base pointer that we've just written was not null.
+    unsafe { NonNull::new_unchecked(raw_unsized as *mut U) }
+}

--- a/alloc-traits/src/unsize.rs
+++ b/alloc-traits/src/unsize.rs
@@ -192,6 +192,7 @@ coerce_to_dyn_trait!(
     fn to_display() -> core::fmt::Display
 );
 
+#[cfg(rustc_1_51)]
 impl<T, const N: usize> Coercion<[T; N], [T]> {
     /// Create a coercer that unsizes an array to a slice.
     ///

--- a/alloc-traits/tests/unsize.rs
+++ b/alloc-traits/tests/unsize.rs
@@ -1,0 +1,59 @@
+
+use alloc_traits::{Coercion, CoerceUnsize};
+
+#[test]
+fn any() {
+    use core::any::Any;
+    fn generic<T: Any>(ptr: &T) -> &dyn Any {
+        ptr.unsize(Coercion::to_any())
+    }
+    generic(&0u32);
+}
+
+#[test]
+fn debug() {
+    use core::fmt::Debug;
+    fn generic<T: Debug>(ptr: &T) -> &dyn Debug {
+        ptr.unsize(Coercion::to_debug())
+    }
+    generic(&0u32);
+}
+
+#[test]
+fn display() {
+    use core::fmt::Display;
+    fn generic<T: Display>(ptr: &T) -> &dyn Display {
+        ptr.unsize(Coercion::to_display())
+    }
+    generic(&0u32);
+}
+
+#[cfg(rustc_1_51)]
+#[test]
+fn to_slice() {
+    fn generic<T>(ptr: &[T; 4]) -> &[T] {
+        ptr.unsize(Coercion::to_slice())
+    }
+    generic(&[0u32; 4]);
+}
+
+#[test]
+fn functions() {
+    fn arg0<F: 'static + FnOnce()>(fptr: &F) -> &dyn FnOnce() {
+        fptr.unsize(Coercion::<_, dyn FnOnce()>::to_fn_once())
+    }
+
+    fn arg1<F: 'static + FnOnce(u32)>(fptr: &F) -> &dyn FnOnce(u32) {
+        fptr.unsize(Coercion::<_, dyn FnOnce(u32)>::to_fn_once())
+    }
+
+    fn arg6<F: 'static + FnOnce(u32,u32,u32,u32,u32,u32)>(fptr: &F) 
+        -> &dyn FnOnce(u32,u32,u32,u32,u32,u32)
+    {
+        fptr.unsize(Coercion::<_, dyn FnOnce(u32,u32,u32,u32,u32,u32)>::to_fn_once())
+    }
+
+    arg0(&|| {});
+    arg1(&|_| {});
+    arg6(&|_,_,_,_,_,_| {});
+}

--- a/without-alloc/src/boxed.rs
+++ b/without-alloc/src/boxed.rs
@@ -5,6 +5,7 @@
 //! [`Box`]: struct.Box.html
 use core::{borrow, cmp, fmt, hash, mem, ops, ptr};
 use crate::uninit::Uninit;
+use alloc_traits::CoerceUnsize;
 
 /// An allocated instance of a type.
 ///
@@ -61,6 +62,37 @@ use crate::uninit::Uninit;
 /// one `usize` more space usage) via a wrapper when an allocator is available.
 pub struct Box<'a, T: ?Sized> {
     inner: Uninit<'a, T>,
+}
+
+
+/// Unsize a Box, for example into a dynamic trait object.
+///
+/// # Usage
+///
+/// ```
+/// # use without_alloc::boxed::Box;
+/// use alloc_traits::{Coercion, CoerceUnsizeExt};
+/// use without_alloc::Uninit;
+/// use core::mem::MaybeUninit;
+///
+/// let mut memory: MaybeUninit<usize> = MaybeUninit::uninit();
+/// let boxed = Box::new(0usize, Uninit::from(&mut memory));
+///
+/// let debug: Box<dyn core::fmt::Debug> = unsafe {
+///     boxed.unsize(Coercion::to_debug())
+/// };
+/// ```
+unsafe impl<'a, T, U: ?Sized> CoerceUnsize<U> for Box<'a, T> {
+    type Pointee = T;
+    type Output = Box<'a, U>;
+    fn as_sized_ptr(&self) -> *mut T {
+        self.inner.as_ptr()
+    }
+    unsafe fn replace_ptr(self, new: *mut U) -> Box<'a, U> {
+        let inner = Box::into_raw(self);
+        let inner = inner.replace_ptr(new);
+        Box::from_raw(inner)
+    }
 }
 
 impl<'a, T> Box<'a, T> {

--- a/without-alloc/src/boxed.rs
+++ b/without-alloc/src/boxed.rs
@@ -5,7 +5,7 @@
 //! [`Box`]: struct.Box.html
 use core::{borrow, cmp, fmt, hash, mem, ops, ptr};
 use crate::uninit::Uninit;
-use alloc_traits::CoerceUnsize;
+use alloc_traits::CoerciblePtr;
 
 /// An allocated instance of a type.
 ///
@@ -71,7 +71,7 @@ pub struct Box<'a, T: ?Sized> {
 ///
 /// ```
 /// # use without_alloc::boxed::Box;
-/// use alloc_traits::{Coercion, CoerceUnsizeExt};
+/// use alloc_traits::{Coercion, CoerceUnsize};
 /// use without_alloc::Uninit;
 /// use core::mem::MaybeUninit;
 ///
@@ -82,7 +82,7 @@ pub struct Box<'a, T: ?Sized> {
 ///     boxed.unsize(Coercion::to_debug())
 /// };
 /// ```
-unsafe impl<'a, T, U: ?Sized> CoerceUnsize<U> for Box<'a, T> {
+unsafe impl<'a, T, U: ?Sized> CoerciblePtr<U> for Box<'a, T> {
     type Pointee = T;
     type Output = Box<'a, U>;
     fn as_sized_ptr(&self) -> *mut T {

--- a/without-alloc/src/uninit.rs
+++ b/without-alloc/src/uninit.rs
@@ -23,7 +23,7 @@ use core::alloc::Layout;
 use core::marker::PhantomData;
 
 use crate::boxed::Box;
-use alloc_traits::CoerceUnsize;
+use alloc_traits::CoerciblePtr;
 
 /// Points to an uninitialized place but would otherwise be a valid reference.
 ///
@@ -973,7 +973,7 @@ impl<T: ?Sized> Clone for UninitView<'_, T> {
 
 impl<T: ?Sized> Copy for UninitView<'_, T> { }
 
-unsafe impl<'a, T, U: ?Sized> CoerceUnsize<U> for UninitView<'a, T> {
+unsafe impl<'a, T, U: ?Sized> CoerciblePtr<U> for UninitView<'a, T> {
     type Pointee = T;
     type Output = UninitView<'a, U>;
     fn as_sized_ptr(&self) -> *mut T {
@@ -988,7 +988,7 @@ unsafe impl<'a, T, U: ?Sized> CoerceUnsize<U> for UninitView<'a, T> {
     }
 }
 
-unsafe impl<'a, T, U: ?Sized> CoerceUnsize<U> for Uninit<'a, T> {
+unsafe impl<'a, T, U: ?Sized> CoerciblePtr<U> for Uninit<'a, T> {
     type Pointee = T;
     type Output = Uninit<'a, U>;
 

--- a/without-alloc/tests/unsize.rs
+++ b/without-alloc/tests/unsize.rs
@@ -1,4 +1,4 @@
-use alloc_traits::{Coercion, CoerceUnsizeExt};
+use alloc_traits::{Coercion, CoerceUnsize};
 use without_alloc::{boxed::Box, Uninit};
 use core::mem::MaybeUninit;
 

--- a/without-alloc/tests/unsize.rs
+++ b/without-alloc/tests/unsize.rs
@@ -1,0 +1,13 @@
+use alloc_traits::{Coercion, CoerceUnsizeExt};
+use without_alloc::{boxed::Box, Uninit};
+use core::mem::MaybeUninit;
+
+#[test]
+fn unsizing() {
+    let mut memory: MaybeUninit<usize> = MaybeUninit::uninit();
+    let boxed = Box::new(0usize, Uninit::from(&mut memory));
+
+    let debug: Box<dyn core::fmt::Debug> = boxed.unsize(Coercion::to_debug());
+
+    assert_eq!(format!("{:?}", &*debug), "0");
+}


### PR DESCRIPTION
We construct a witness type attesting and implementing the coercion
itself which allows pointers to compose. This also relaxes the
requirements from a reference to a raw pointer, which makes it
applicable to uninit boxes and other types that can not create a
reference.