### PR TITLE
Add a pin utility, ExitStack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
+**/target/rls
+**/target/CACHEDIR.TAG
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"alloc-traits",
+	"exit-stack",
 	"fill",
 	"static-alloc",
 	"without-alloc",

--- a/exit-stack/Cargo.toml
+++ b/exit-stack/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "exit-stack"
+version = "0.1.0"
+description = "Dynamically pin values to the stack, with no macros."
+authors = ["Andreas Molzer <andreas.molzer@gmx.de>"]
+edition = "2018"
+license = "MIT"
+documentation = "https://docs.rs/exit-stack"
+repository = "https://github.com/HeroicKatora/static-alloc"
+readme = "Readme.md"
+categories = ["embedded", "memory-management", "no-std"]
+
+[dependencies]
+static-alloc = { path = "../static-alloc" }
+
+[dev-dependencies]
+pin-utils = "0.1"

--- a/exit-stack/Readme.md
+++ b/exit-stack/Readme.md
@@ -1,0 +1,3 @@
+# exit-stack
+
+Dynamically pin values to the stack.

--- a/exit-stack/src/lib.rs
+++ b/exit-stack/src/lib.rs
@@ -1,0 +1,160 @@
+#![no_std]
+use core::cell::Cell;
+use core::mem::MaybeUninit;
+use core::pin::Pin;
+use core::ptr::NonNull;
+
+use static_alloc::leaked::LeakBox;
+use static_alloc::unsync::Bump;
+
+pub struct ExitStack<Mem> {
+    memory: Bump<Mem>,
+    top: Cell<Option<ExitHandle>>,
+}
+
+type ExitHandle = NonNull<PinSlot<dyn Drop>>;
+
+pub struct ExitStackSlot<'lt, T> {
+    /// Where we will commit ourselves to pin the value. If we write a pointer here then it _must_
+    /// be dropped before the box's memory is invalidated.
+    slotter: &'lt Cell<Option<ExitHandle>>,
+    /// The slot which we can fill with a value and meta data.
+    value: LeakBox<'lt, MaybeUninit<PinSlot<T>>>,
+}
+
+/// One entry in the exit stack linked list.
+struct PinSlot<T: ?Sized> {
+    link: Option<ExitHandle>,
+    value: T,
+}
+
+impl<Mem> ExitStack<Mem> {
+    pub fn new() -> Self {
+        ExitStack {
+            memory: Bump::uninit(),
+            top: Cell::new(None),
+        }
+    }
+
+    /// Prepare a slot for pinning a value to the stack.
+    pub fn slot<'stack, T: 'static>(self: Pin<&'stack Self>)
+        -> Option<ExitStackSlot<'stack, T>>
+    {
+        let this: &'stack Self = self.get_ref();
+        let value = this.memory.bump_box().ok()?;
+        Some(ExitStackSlot {
+            slotter: &this.top,
+            value,
+        })
+    }
+
+    /// Drop all values, resetting the stack.
+    pub fn pop_all(self: Pin<&mut Self>) {
+        unsafe {
+            // SAFETY: inner_pop_all_with_unsafe_self_and_pinned will not move a pinned value.
+            self.get_unchecked_mut().inner_pop_all_with_unsafe_self_and_pinned()
+        }
+    }
+
+    fn inner_pop_all_with_unsafe_self_and_pinned(&mut self) {
+        // Ensures that, if we panic unwind, the rest continues to be dropped under the threat of aborting.
+        struct UnwindFlag {
+            chain: Option<ExitHandle>,
+        }
+
+        // !!! In case of another panic we _will_ abort, ourselves, not depending on Rust !!!
+        impl core::ops::Drop for UnwindFlag {
+            fn drop(&mut self) {
+                while let Some(exit_handle) = self.chain {
+                    // SAFETY: we only store pointers to the same stack here, which is still valid.
+                    let slot = unsafe { &mut *exit_handle.as_ptr() };
+                    let abort_flag = AbortOnDrop;
+                    // SAFETY: fulfilling our pin promise here.
+                    // This is also uniquely dropped as it was owned by `self.chain` before.
+                    unsafe { core::ptr::drop_in_place(&mut slot.value) };
+                    // Oh great, we didn't panic calling this drop. Let's not abort.
+                    core::mem::forget(abort_flag);
+                    self.chain = slot.link;
+                }
+            }
+        }
+
+        let mut flag = UnwindFlag { chain: self.top.take() };
+
+        while let Some(exit_handle) = flag.chain.take() {
+            // SAFETY: we only store pointers to the same stack here, which is still valid.
+            let slot = unsafe { &mut *exit_handle.as_ptr() };
+            // This is also uniquely dropped as it was owned by `flag.chain` before.
+            unsafe { core::ptr::drop_in_place(&mut slot.value) };
+            flag.chain = slot.link;
+        }
+    }
+}
+
+impl<'lt, T> ExitStackSlot<'lt, T> {
+    /// Pin a value to the stack.
+    ///
+    /// Returns the value if there is no more space in the reserved portion of memory to pin the
+    /// new value. You might try calling `pop_all` then to free some.
+    ///
+    /// Note that dropping might be delayed arbitrarily as the ExitStack has no control over its
+    /// own drop point, hence values must live for a static duration.
+    pub fn pin(self, value: T) -> Pin<&'lt mut T>
+    where
+        T: 'static
+    {
+        // Store the old pointer into our linked list.
+        let link = self.slotter.get();
+        let boxed = LeakBox::write(self.value, PinSlot { link, value });
+        // Now round-trip through pointer. Guarantees that the returned value is based on the
+        // pointer we store in the exit stack, which is required for provenance reasons.
+        // Has Shared-read-write ..
+        let pointer = LeakBox::into_raw(boxed);
+        // .. so does this shared-read-write.
+        let exit_handle: *mut PinSlot<dyn Drop> = pointer;
+        // Overwrite the pointer that is dropped first. The old still has a guarantee of being
+        // dropped because the ExitStack will iterate over us, guaranteed with this same write as
+        // we've set the link to the old pointer.
+        self.slotter.set(NonNull::new(exit_handle));
+        // .. so this is unique write above these two pointers.
+        // Pin is sound because we've registered ourselves in slotter.
+        unsafe { Pin::new_unchecked(&mut (*pointer).value) }
+    }
+
+    #[allow(dead_code)] // Might pub this later.
+    unsafe fn pin_local(self, _: T) -> Pin<&'lt mut T> {
+        unimplemented!()
+    }
+}
+
+impl<Mem> core::ops::Drop for ExitStack<Mem> {
+    fn drop(&mut self) {
+        self.inner_pop_all_with_unsafe_self_and_pinned()
+    }
+}
+
+/// An object-safe trait for types that are droppable. So, all of them.
+trait Drop {}
+
+impl<T: ?Sized> Drop for T {}
+
+// A struct that guarantees that no more execution happens after it is dropped. It must be
+// forgotten, a very strong pre-pooping of our pants.
+struct AbortOnDrop;
+impl core::ops::Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        struct CauseDoublePanic;
+        impl core::ops::Drop for CauseDoublePanic {
+            fn drop(&mut self) { panic!() }
+        }
+        struct FallbackInCaseThisDidntAbort;
+        impl core::ops::Drop for FallbackInCaseThisDidntAbort {
+            fn drop(&mut self) { loop {} }
+        }
+        // Since we are no_std.. FIXME: use `cfg(accessible())` once stabilized to abort.
+        let _v = FallbackInCaseThisDidntAbort;
+        let _v = CauseDoublePanic;
+        panic!();
+    }
+}
+

--- a/exit-stack/tests/stackful.rs
+++ b/exit-stack/tests/stackful.rs
@@ -6,15 +6,6 @@ use std::rc::Rc;
 
 #[test]
 fn run_with_a_stack() {
-    struct DropCheck(Rc<Cell<usize>>);
-
-    impl Drop for DropCheck {
-        fn drop(&mut self) {
-            let val = self.0.get();
-            self.0.set(val + 1);
-        }
-    }
-
     let drop_target = Rc::new(Cell::default());
 
     {
@@ -23,7 +14,7 @@ fn run_with_a_stack() {
 
         for _ in 0..32 {
             let slot = exit_stack.as_ref().slot().unwrap();
-            let pinnable = DropCheck(Rc::clone(&drop_target));
+            let pinnable = DropCheck::new(&drop_target);
             // A pinned value, but we're using the outer stack space.
             let _: Pin<_> = slot.pin(pinnable);
         }
@@ -34,15 +25,6 @@ fn run_with_a_stack() {
 
 #[test]
 fn run_with_a_heap_stack() {
-    struct DropCheck(Rc<Cell<usize>>);
-
-    impl Drop for DropCheck {
-        fn drop(&mut self) {
-            let val = self.0.get();
-            self.0.set(val + 1);
-        }
-    }
-
     let drop_target = Rc::new(Cell::default());
 
     {
@@ -50,11 +32,65 @@ fn run_with_a_heap_stack() {
 
         for _ in 0..32 {
             let slot = exit_stack.as_ref().slot().unwrap();
-            let pinnable = DropCheck(Rc::clone(&drop_target));
+            let pinnable = DropCheck::new(&drop_target);
             // A pinned value, but we're using space of the heap, pinned to the stack. Crazy.
             let _: Pin<_> = slot.pin(pinnable);
         }
     }
 
     assert_eq!(drop_target.get(), 32, "Not dropped as often as expected");
+}
+
+#[test]
+fn set_with_various_sizes() {
+    fn set_with_t<T: Default + 'static>() {
+        let exit_stack: ExitStack<T> = ExitStack::new();
+        pin_utils::pin_mut!(exit_stack);
+        let _ = exit_stack.set(T::default());
+    }
+
+    #[derive(Default)]
+    struct Zst;
+    #[derive(Default)]
+    struct Large([u64; 32]);
+
+    set_with_t::<Zst>();
+    set_with_t::<Large>();
+}
+
+#[test]
+fn set_drops_correctly() {
+    let drop_target = Default::default();
+
+    {
+        let exit_stack: ExitStack<DropCheck> = ExitStack::new();
+        pin_utils::pin_mut!(exit_stack);
+        // Check that this succeeds.
+        let _ = exit_stack.as_mut().set(DropCheck::new(&drop_target));
+        // Didn't drop any value yet, though we didn't capture it.
+        assert_eq!(drop_target.get(), 0);
+
+        // Check that this succeeds, a second time.
+        let _ = exit_stack.set(DropCheck::new(&drop_target));
+        // The first was dropped as part of this.
+        assert_eq!(drop_target.get(), 1);
+    }
+
+    // Now the exit_stack was dropped, and the second value with it.
+    assert_eq!(drop_target.get(), 2);
+}
+
+struct DropCheck(Rc<Cell<usize>>);
+
+impl Drop for DropCheck {
+    fn drop(&mut self) {
+        let val = self.0.get();
+        self.0.set(val + 1);
+    }
+}
+
+impl DropCheck {
+    fn new(cell: &'_ Rc<Cell<usize>>) -> Self {
+        DropCheck(Rc::clone(cell))
+    }
 }

--- a/exit-stack/tests/stackful.rs
+++ b/exit-stack/tests/stackful.rs
@@ -1,0 +1,60 @@
+use core::cell::Cell;
+use core::pin::Pin;
+
+use exit_stack::ExitStack;
+use std::rc::Rc;
+
+#[test]
+fn run_with_a_stack() {
+    struct DropCheck(Rc<Cell<usize>>);
+
+    impl Drop for DropCheck {
+        fn drop(&mut self) {
+            let val = self.0.get();
+            self.0.set(val + 1);
+        }
+    }
+
+    let drop_target = Rc::new(Cell::default());
+
+    {
+        let exit_stack: ExitStack<[usize; 96]> = ExitStack::new();
+        pin_utils::pin_mut!(exit_stack);
+
+        for _ in 0..32 {
+            let slot = exit_stack.as_ref().slot().unwrap();
+            let pinnable = DropCheck(Rc::clone(&drop_target));
+            // A pinned value, but we're using the outer stack space.
+            let _: Pin<_> = slot.pin(pinnable);
+        }
+    }
+
+    assert_eq!(drop_target.get(), 32, "Not dropped as often as expected");
+}
+
+#[test]
+fn run_with_a_heap_stack() {
+    struct DropCheck(Rc<Cell<usize>>);
+
+    impl Drop for DropCheck {
+        fn drop(&mut self) {
+            let val = self.0.get();
+            self.0.set(val + 1);
+        }
+    }
+
+    let drop_target = Rc::new(Cell::default());
+
+    {
+        let exit_stack: Pin<Box<ExitStack<[usize; 2048]>>> = Box::pin(ExitStack::new());
+
+        for _ in 0..32 {
+            let slot = exit_stack.as_ref().slot().unwrap();
+            let pinnable = DropCheck(Rc::clone(&drop_target));
+            // A pinned value, but we're using space of the heap, pinned to the stack. Crazy.
+            let _: Pin<_> = slot.pin(pinnable);
+        }
+    }
+
+    assert_eq!(drop_target.get(), 32, "Not dropped as often as expected");
+}


### PR DESCRIPTION
It's based off the guarantees from static_alloc that allow us to
allocate pseudo-stack space from without ourselves. This allows us to
leverage an immovability guarantee of our own to guarantee that a stack
of values allocated from within does not move, and is properly dropped.