### PR TITLE
Improvements and fixes for `::unsize`'s release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,6 +52,14 @@ miri_without_alloc_task:
     - cd without-alloc
     - rustup run nightly cargo-miri miri test
 
+miri_unsize_task:
+  container:
+    image: rustlang/rust:nightly
+  script:
+    - rustup component add --toolchain nightly miri
+    - cd unsize
+    - rustup run nightly cargo-miri miri test
+
 release_task:
   only_if: $CIRRUS_BRANCH =~ 'release-fill.*'
   container:

--- a/unsize/src/coercion_impls.rs
+++ b/unsize/src/coercion_impls.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+use ::core::{
+    fmt,
+    hash::{Hash, Hasher},
+};
+
+impl<T, U : ?Sized, F : FnOnce(*const T) -> *const U> Clone
+    for Coercion<T, U, F>
+where
+    F : Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            coerce: self.coerce.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, U : ?Sized, F : FnOnce(*const T) -> *const U> Copy
+    for Coercion<T, U, F>
+where
+    F : Copy,
+{}
+
+impl<T, U : ?Sized, F : FnOnce(*const T) -> *const U> PartialEq
+    for Coercion<T, U, F>
+where
+    F : PartialEq,
+{
+    fn eq(self: &Self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self {
+                    coerce: coerce_left,
+                    _phantom: _,
+                },
+                Self {
+                    coerce: coerce_right,
+                    _phantom: _,
+                },
+            ) => coerce_left == coerce_right,
+        }
+    }
+}
+
+impl<T, U : ?Sized, F : FnOnce(*const T) -> *const U> Eq
+    for Coercion<T, U, F>
+where
+    F : Eq,
+{}
+
+impl<T, U : ?Sized, F : FnOnce(*const T) -> *const U> fmt::Debug
+    for Coercion<T, U, F>
+where
+    F : fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f   .debug_struct("Coercion")
+            .field("coerce", &self.coerce)
+            .finish()
+    }
+}
+
+impl<T, U : ?Sized, F : FnOnce(*const T) -> *const U> Hash
+    for Coercion<T, U, F>
+where
+    F : Hash,
+{
+    fn hash<H : Hasher>(&self, state: &mut H) {
+        (&self.coerce).hash(state)
+    }
+}

--- a/unsize/src/lib.rs
+++ b/unsize/src/lib.rs
@@ -47,10 +47,10 @@ mod impls {
         }
     }
 
-    unsafe impl<Ptr, U, T> CoerciblePtr<U> for core::pin::Pin<Ptr>
+    unsafe impl<Ptr, U : ?Sized, T> CoerciblePtr<U> for core::pin::Pin<Ptr>
     where
         Ptr: CoerciblePtr<U> + core::ops::Deref<Target=T>,
-        Ptr::Output: core::ops::Deref<Target=T>,
+        Ptr::Output: core::ops::Deref<Target=U>,
     {
         type Pointee = T;
         type Output = core::pin::Pin<Ptr::Output>;

--- a/unsize/src/lib.rs
+++ b/unsize/src/lib.rs
@@ -397,3 +397,32 @@ extern {}
 
 #[cfg(test)]
 mod tests;
+
+/// Non-`unsafe` [`struct@Coercion`] constructor for arbitrary trait bounds.
+///
+/// # Example
+// (and test!)
+///
+/// ```rust
+/// use unsize::Coercion;
+///
+/// trait MyFancyTrait { /* … */ }
+///
+/// fn generic<T: MyFancyTrait>(ptr: &T) -> &dyn MyFancyTrait {
+///     ptr.unsize(Coercion!(to dyn MyFancyTrait))
+/// }
+/// ```
+#[macro_export]
+macro_rules! Coercion {
+    (to dyn $($bounds:tt)*) => (
+        #[allow(unused_unsafe)] unsafe {
+            $crate::Coercion::new({
+                #[allow(unused_parens)]
+                fn coerce (p: *mut (impl $($bounds)*)) -> *mut (dyn $($bounds)*) {
+                    p
+                }
+                coerce
+            })
+        }
+    );
+}

--- a/unsize/src/tests.rs
+++ b/unsize/src/tests.rs
@@ -1,0 +1,50 @@
+use super::*;
+
+macro_rules! assert_impls {(
+    for [$($generics:tt)*]
+    $T:ty : $($bounds:tt)*
+) => (
+    const _: () = {
+        fn _for<$($generics)*> ()
+        {
+            fn bounds_check<__>() where
+                __ : $($bounds)*
+            {}
+            let _ = bounds_check::<$T>;
+        }
+    };
+)}
+
+assert_impls! {
+    for[
+        // The pointees' lack of bounds should not make `Coercion` lack the bounds too.
+        T, U : ?Sized,
+    ]
+    Coercion<T, U> :
+        Copy +
+        Clone +
+        PartialEq +
+        Eq +
+        ::core::hash::Hash +
+}
+
+// More generally,
+assert_impls! {
+    for[
+        // The pointees' lack of bounds should not make `Coercion` lack the bounds too.
+        T, U : ?Sized,
+        F :
+            Copy +
+            Clone +
+            PartialEq +
+            Eq +
+            ::core::hash::Hash +
+        ,
+    ]
+    Coercion<T, U, F> :
+        Copy +
+        Clone +
+        PartialEq +
+        Eq +
+        ::core::hash::Hash +
+}

--- a/unsize/src/tests.rs
+++ b/unsize/src/tests.rs
@@ -34,6 +34,7 @@ assert_impls! {
         // The pointees' lack of bounds should not make `Coercion` lack the bounds too.
         T, U : ?Sized,
         F :
+            FnOnce(*const T) -> *const U +
             Copy +
             Clone +
             PartialEq +

--- a/unsize/tests/unsize.rs
+++ b/unsize/tests/unsize.rs
@@ -7,6 +7,19 @@ fn any() {
         ptr.unsize(Coercion::to_any())
     }
     generic(&0u32);
+    fn generic_mut<T: Any>(ptr: &mut T) -> &mut dyn Any {
+        ptr.unsize(Coercion::to_any())
+    }
+    generic_mut(&mut 0u32);
+    use core::pin::Pin;
+    fn generic_mut_pinned<T: Any>(ptr: Pin<&mut T>) -> Pin<&mut dyn Any> {
+        ptr.unsize(Coercion::to_any())
+    }
+    let mut p = (0_u32, ::core::marker::PhantomPinned);
+    let p = unsafe {
+        Pin::new_unchecked(&mut p)
+    };
+    generic_mut_pinned(p);
 }
 
 #[test]
@@ -46,7 +59,7 @@ fn functions() {
         fptr.unsize(Coercion::<_, dyn FnOnce(u32)>::to_fn_once())
     }
 
-    fn arg6<F: 'static + FnOnce(u32,u32,u32,u32,u32,u32)>(fptr: &F) 
+    fn arg6<F: 'static + FnOnce(u32,u32,u32,u32,u32,u32)>(fptr: &F)
         -> &dyn FnOnce(u32,u32,u32,u32,u32,u32)
     {
         fptr.unsize(Coercion::<_, dyn FnOnce(u32,u32,u32,u32,u32,u32)>::to_fn_once())


### PR DESCRIPTION
  - [x] Fix the blanket impl for `Pin`, and add a test for it (which ought to showcase a provenance soundness error in its impl):

      - [ ] ~~Change a bit the signatures of `CoerciblePtr` methods to fix the provenance issues;~~

  - [x] Improve the design of `Coerce` & `CoerceWith`: a generic `F : FnOnce(*const T) -> *const U` (with an optional `F = fn…` default) + prevent the `#[derive(…)]`-introduced bounds from infecting `T` and `U`

  - [x] Feature a public macro for a non-`unsafe` arbitrary `dyn` coercion