### PR TITLE
Add support for `thumbv6m` targets using the `atomic-polyfill` crate

### DIFF
--- a/static-alloc/Cargo.toml
+++ b/static-alloc/Cargo.toml
@@ -10,8 +10,12 @@ repository = "https://github.com/HeroicKatora/static-alloc"
 readme = "Readme.md"
 categories = ["embedded", "memory-management", "no-std"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 alloc-traits = { path = "../alloc-traits", version = "0.1.0" }
+atomic-polyfill = { version = "0.1.2", optional = true }
 
 [features]
 alloc = []
@@ -21,6 +25,7 @@ nightly_try_reserve = []
 # Enables the `unsync::Chain` module. Note that this is explicitly outside the
 # SemVer stability guarantees!
 nightly_chain = ["alloc"]
+polyfill = ["atomic-polyfill"]
 
 # Tests that test `Bump` as GlobalAlloc. Must be in a separate test each.
 [[test]]
@@ -42,6 +47,3 @@ required-features = ["DISABLED"]
 name = "unsync"
 path = "tests/unsync.rs"
 required-features = ["alloc"]
-
-[package.metadata.docs.rs]
-all-features = true

--- a/static-alloc/Cargo.toml
+++ b/static-alloc/Cargo.toml
@@ -25,6 +25,8 @@ nightly_try_reserve = []
 # Enables the `unsync::Chain` module. Note that this is explicitly outside the
 # SemVer stability guarantees!
 nightly_chain = ["alloc"]
+# Enables the use of the `atomic-polyfill` crate to support targets without
+# native atomic CAS operations
 polyfill = ["atomic-polyfill"]
 
 # Tests that test `Bump` as GlobalAlloc. Must be in a separate test each.

--- a/static-alloc/Changes.md
+++ b/static-alloc/Changes.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Added support for `thumbv6m` targets through use of `atomic-polyfill`
+
 # v0.2.2
 
 - Added a synchronous Bump allocator. Its interface is similar to the

--- a/static-alloc/src/bump.rs
+++ b/static-alloc/src/bump.rs
@@ -770,16 +770,12 @@ impl<T> Bump<T> {
         assert!(expect_consumed <= new_consumed);
         assert!(new_consumed <= mem::size_of::<T>());
 
-        #[allow(deprecated)]
-        let observed = self.consumed.compare_and_swap(
+        self.consumed.compare_exchange(
             expect_consumed,
             new_consumed,
-            Ordering::SeqCst);
-        if expect_consumed == observed {
-            Ok(())
-        } else {
-            Err(observed)
-        }
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ).map(drop)
     }
 }
 


### PR DESCRIPTION
Hey, there, I am using this change to allow for thumbv6 target support (which do not have an atomic compare-and-swap capability), and the `atomic-polyfill` is a compatible API that inserts critical-sections for compatibility on those targets (on non-thumbv6 targets, it just re-exports `core`'s atomics).

Right now, polyfill doesn't re-export the deprecated `compare_and_swap`, so I ported the usage over based on `core`'s porting recommendations. This should not result in a functional change for any currently supported targets.

I plan to use this for the next release of [`cassette`](https://docs.rs/cassette), let me know if you're interested in this!