### PR TITLE
Implement CoerciblePtr for stdlib smart pointers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ miri_unsize_task:
   script:
     - rustup component add --toolchain nightly miri
     - cd unsize
-    - rustup run nightly cargo-miri miri test
+    - rustup run nightly cargo-miri miri test --all-features
 
 release_task:
   only_if: $CIRRUS_BRANCH =~ 'release-fill.*'

--- a/unsize/Cargo.toml
+++ b/unsize/Cargo.toml
@@ -12,6 +12,12 @@ categories = ["embedded", "no-std"]
 
 [dependencies]
 
+[features]
+# Implement CoerecePtr for `alloc` pointer types
+alloc = []
+# Implement Unsize for `std` pointer types
+std = ["alloc"]
+
 [build-dependencies]
 autocfg = "1"
 

--- a/unsize/Cargo.toml
+++ b/unsize/Cargo.toml
@@ -15,8 +15,6 @@ categories = ["embedded", "no-std"]
 [features]
 # Implement CoerecePtr for `alloc` pointer types
 alloc = []
-# Implement Unsize for `std` pointer types
-std = ["alloc"]
 
 [build-dependencies]
 autocfg = "1"

--- a/unsize/build.rs
+++ b/unsize/build.rs
@@ -1,4 +1,6 @@
 fn main() {
     let ac = autocfg::new();
     ac.emit_rustc_version(1, 51);
+    // support for Weak::into_raw
+    ac.emit_rustc_version(1, 45);
 }

--- a/unsize/src/alloc_impls.rs
+++ b/unsize/src/alloc_impls.rs
@@ -1,0 +1,62 @@
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+#[cfg(rustc_1_45)]
+use alloc::rc::Weak as WeakRc;
+#[cfg(rustc_1_45)]
+use alloc::sync::Weak as WeakArc;
+
+use super::CoerciblePtr;
+
+macro_rules! smart_ptr_to_from_raw {
+    (unsafe impl $tgt:ident) => (smart_ptr_to_from_raw! {
+        unsafe impl $tgt {
+            fn as_sized_ptr(&mut self) -> *mut T {
+                // Use deref to acquire pointer to self
+                // NOTE: Turning this into an &mut T is UB if there is shared ownership
+                (&**self) as *const T as *mut T
+            }
+        }
+    });
+    (unsafe impl $tgt:ident { $($items:tt)* }) => {
+        unsafe impl<T, U: ?Sized> CoerciblePtr<U> for $tgt<T> {
+            type Pointee = T;
+            type Output = $tgt<U>;
+            $($items)*
+            unsafe fn replace_ptr(self, new: *mut U) -> $tgt<U> {
+                unsafe {
+                    // SAFETY: Caller has guarenteed that `new` is
+                    // just an unsized version of the original
+                    //
+                    // Ownership is correctly transfered from `self` to result.
+                    // NOTE: Leaks memory if unsize_with panics
+                    $tgt::from_raw(crate::unsize_with($tgt::into_raw(self) as *mut T, |_| new))
+                }
+            }
+        }
+    }
+}
+smart_ptr_to_from_raw!(unsafe impl Box);
+smart_ptr_to_from_raw!(unsafe impl Rc);
+smart_ptr_to_from_raw!(unsafe impl Arc);
+#[cfg(rustc_1_45)] // Weak::from_raw, Weak::as_ptr only on 1.45
+smart_ptr_to_from_raw!(unsafe impl WeakRc {
+    fn as_sized_ptr(&mut self) -> *mut T {
+        // The safety of this implementation is subtle.
+        // If there are still strong references, everything works like Rc.
+        // If there are no strong references,
+        // the result of Weak::as_ptr is well-defined but dangling
+        //
+        // Furthermore, it is still safe to call
+        // Weak::from_raw even with a strong count of zero
+        // as long as we still own a weak reference
+        WeakRc::as_ptr(&*self) as *mut T
+    }
+});
+#[cfg(rustc_1_45)] // std::sync::Arc works same as std::rc::Arc
+smart_ptr_to_from_raw!(unsafe impl WeakArc {
+    fn as_sized_ptr(&mut self) -> *mut T {
+        // Safety of this implementation is safe as for WeakRc
+        WeakArc::as_ptr(&*self) as *mut T
+    }
+});

--- a/unsize/src/alloc_impls.rs
+++ b/unsize/src/alloc_impls.rs
@@ -50,13 +50,13 @@ smart_ptr_to_from_raw!(unsafe impl WeakRc {
         // Furthermore, it is still safe to call
         // Weak::from_raw even with a strong count of zero
         // as long as we still own a weak reference
-        WeakRc::as_ptr(&*self) as *mut T
+        WeakRc::as_ptr(self) as *mut T
     }
 });
 #[cfg(rustc_1_45)] // std::sync::Arc works same as std::rc::Arc
 smart_ptr_to_from_raw!(unsafe impl WeakArc {
     fn as_sized_ptr(&mut self) -> *mut T {
         // Safety of this implementation is safe as for WeakRc
-        WeakArc::as_ptr(&*self) as *mut T
+        WeakArc::as_ptr(self) as *mut T
     }
 });

--- a/unsize/src/alloc_impls.rs
+++ b/unsize/src/alloc_impls.rs
@@ -29,8 +29,13 @@ macro_rules! smart_ptr_to_from_raw {
                     // just an unsized version of the original
                     //
                     // Ownership is correctly transfered from `self` to result.
-                    // NOTE: Leaks memory if unsize_with panics
-                    $tgt::from_raw(crate::unsize_with($tgt::into_raw(self) as *mut T, |_| new))
+
+                    // Provenance transfered into `raw` as per each individual `into_raw`.
+                    let raw = $tgt::into_raw(self) as *mut T;
+                    // Provenance merged into `new` as per `replace_ptr`.
+                    let new: *mut U = <*mut T as CoerciblePtr<U>>::replace_ptr(raw, new);
+                    // Provenance transferred as per `from_raw`.
+                    $tgt::from_raw(new)
                 }
             }
         }

--- a/unsize/src/lib.rs
+++ b/unsize/src/lib.rs
@@ -26,6 +26,9 @@ use core::{
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "alloc")]
+mod alloc_impls;
+
 mod impls {
     //! Safety: Provenance is always the same as self, pointer target is simply passed through.
     use core::ptr::NonNull;
@@ -113,71 +116,6 @@ mod impls {
             // Safety:
             NonNull::new_unchecked(new)
         }
-    }
-
-    #[cfg(feature = "alloc")]
-    mod alloc_impls {
-        use crate::CoerciblePtr;
-        use alloc::boxed::Box;
-        use alloc::rc::Rc;
-        use alloc::sync::Arc;
-        #[cfg(rustc_1_45)]
-        use alloc::rc::Weak as WeakRc;
-        #[cfg(rustc_1_45)]
-        use alloc::sync::Weak as WeakArc;
-
-        macro_rules! smart_ptr_to_from_raw {
-            (unsafe impl $tgt:ident) => (smart_ptr_to_from_raw! {
-                unsafe impl $tgt {
-                    fn as_sized_ptr(&mut self) -> *mut T {
-                        // Use deref to acquire pointer to self
-                        // NOTE: Turning this into an &mut T is UB if there is shared ownership
-                        (&**self) as *const T as *mut T
-                    }
-                }
-            });
-            (unsafe impl $tgt:ident { $($items:tt)* }) => {
-                unsafe impl<T, U: ?Sized> CoerciblePtr<U> for $tgt<T> {
-                    type Pointee = T;
-                    type Output = $tgt<U>;
-                    $($items)*
-                    unsafe fn replace_ptr(self, new: *mut U) -> $tgt<U> {
-                        unsafe {
-                            // SAFETY: Caller has guarenteed that `new` is
-                            // just an unsized version of the original
-                            //
-                            // Ownership is correctly transfered from `self` to result.
-                            // NOTE: Leaks memory if unsize_with panics
-                            $tgt::from_raw(crate::unsize_with($tgt::into_raw(self) as *mut T, |_| new))
-                        }
-                    }
-                }
-            }
-        }
-        smart_ptr_to_from_raw!(unsafe impl Box);
-        smart_ptr_to_from_raw!(unsafe impl Rc);
-        smart_ptr_to_from_raw!(unsafe impl Arc);
-        #[cfg(rustc_1_45)] // Weak::from_raw, Weak::as_ptr only on 1.45
-        smart_ptr_to_from_raw!(unsafe impl WeakRc {
-            fn as_sized_ptr(&mut self) -> *mut T {
-                // The safety of this implementation is subtle.
-                // If there are still strong references, everything works like Rc.
-                // If there are no strong references,
-                // the result of Weak::as_ptr is well-defined but dangling
-                //
-                // Furthermore, it is still safe to call
-                // Weak::from_raw even with a strong count of zero
-                // as long as we still own a weak reference
-                WeakRc::as_ptr(&*self) as *mut T
-            }
-        });
-        #[cfg(rustc_1_45)] // std::sync::Arc works same as std::rc::Arc
-        smart_ptr_to_from_raw!(unsafe impl WeakArc {
-            fn as_sized_ptr(&mut self) -> *mut T {
-                // Safety of this implementation is safe as for WeakRc
-                WeakArc::as_ptr(&*self) as *mut T
-            }
-        });
     }
 }
 

--- a/unsize/src/lib.rs
+++ b/unsize/src/lib.rs
@@ -13,7 +13,7 @@
 //! pointer wrapper to safely transform itself. Note that for a limited selection of standard
 //! traits we can even go so far as offer pre-built converters that are safe to use in general.
 // Copyright 2019-2021 Andreas Molzer
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![deny(missing_docs)]
 
 #![allow(unused_unsafe)] // Err on the side of caution.

--- a/unsize/tests/alloc.rs
+++ b/unsize/tests/alloc.rs
@@ -1,0 +1,26 @@
+//! Tests that require the `alloc` feature.
+#![cfg(feature = "alloc")]
+use std::fmt::Debug;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use unsize::{Coercion, CoerceUnsized, CoerciblePtr};
+
+
+/// Does an arbitrary coercion for `dyn Debug`
+fn arbitrary_debug<T: CoerciblePtr<dyn Debug, Output=U>, U>(ptr: T) -> U
+    where T::Pointee: Debug + 'static {
+    ptr.unsize(Coercion::to_debug())
+}
+
+const TEST_VAL: &str = "foo";
+fn check_debug<U: AsRef<dyn Debug>>(val: U) {
+    assert_eq!(format!("{:?}", val.as_ref()), format!("{:?}", TEST_VAL))
+}
+
+#[test]
+fn smart_ptrs() {
+    check_debug(arbitrary_debug::<Box<String>, Box<dyn Debug>>(Box::new(TEST_VAL.into())));
+    check_debug(arbitrary_debug::<Rc<String>, Rc<dyn Debug>>(Rc::new(TEST_VAL.into())));
+    check_debug(arbitrary_debug::<Arc<String>, Arc<dyn Debug>>(Arc::new(TEST_VAL.into())));
+}

--- a/unsize/tests/unsize.rs
+++ b/unsize/tests/unsize.rs
@@ -1,4 +1,4 @@
-use unsize::{Coercion, CoerceUnsized, CoerciblePtr};
+use unsize::{Coercion, CoerceUnsized};
 
 #[test]
 fn any() {
@@ -68,25 +68,4 @@ fn functions() {
     arg0(&|| {});
     arg1(&|_| {});
     arg6(&|_,_,_,_,_,_| {});
-}
-
-#[test]
-#[cfg(feature = "alloc")]
-fn smart_ptrs() {
-    use std::fmt::Debug;
-    use std::rc::{Rc, Weak as RcWeak};
-    use std::sync::{Arc, Weak as ArcWeak};
-    use std::sync::Weak;
-    /// Does an arbitrary coercion for `dyn Debug`
-    fn arbitrary<T: CoerciblePtr<dyn Debug, Output=U>, U>(ptr: T) -> U
-        where T::Pointee: Debug + 'static {
-        ptr.unsize(Coercion::to_debug())
-    }
-    const TEST_VAL: &str = "foo";
-    fn check_debug<U: AsRef<dyn Debug>>(val: U) {
-        assert_eq!(format!("{:?}", val.as_ref()), format!("{:?}", TEST_VAL))
-    }
-    check_debug(arbitrary::<Box<String>, Box<dyn Debug>>(Box::new(TEST_VAL.into())));
-    check_debug(arbitrary::<Rc<String>, Rc<dyn Debug>>(Rc::new(TEST_VAL.into())));
-    check_debug(arbitrary::<Arc<String>, Arc<dyn Debug>>(Arc::new(TEST_VAL.into())));
 }

--- a/unsize/tests/unsize.rs
+++ b/unsize/tests/unsize.rs
@@ -1,4 +1,4 @@
-use unsize::{Coercion, CoerceUnsized};
+use unsize::{Coercion, CoerceUnsized, CoerciblePtr};
 
 #[test]
 fn any() {
@@ -68,4 +68,25 @@ fn functions() {
     arg0(&|| {});
     arg1(&|_| {});
     arg6(&|_,_,_,_,_,_| {});
+}
+
+#[test]
+#[cfg(feature = "alloc")]
+fn smart_ptrs() {
+    use std::fmt::Debug;
+    use std::rc::{Rc, Weak as RcWeak};
+    use std::sync::{Arc, Weak as ArcWeak};
+    use std::sync::Weak;
+    /// Does an arbitrary coercion for `dyn Debug`
+    fn arbitrary<T: CoerciblePtr<dyn Debug, Output=U>, U>(ptr: T) -> U
+        where T::Pointee: Debug + 'static {
+        ptr.unsize(Coercion::to_debug())
+    }
+    const TEST_VAL: &str = "foo";
+    fn check_debug<U: AsRef<dyn Debug>>(val: U) {
+        assert_eq!(format!("{:?}", val.as_ref()), format!("{:?}", TEST_VAL))
+    }
+    check_debug(arbitrary::<Box<String>, Box<dyn Debug>>(Box::new(TEST_VAL.into())));
+    check_debug(arbitrary::<Rc<String>, Rc<dyn Debug>>(Rc::new(TEST_VAL.into())));
+    check_debug(arbitrary::<Arc<String>, Arc<dyn Debug>>(Arc::new(TEST_VAL.into())));
 }


### PR DESCRIPTION
Implemented for Box, Rc, Arc from `alloc` crate.
On rust versions since 1.45, implemented for Weak references as well.

Available under `alloc` feature.
Also expose `std` feature, which currently adds nothing beyond `alloc`.

Both these features are off by default for backwards compatibility.
Even though the `std` feature currently adds no implementations,
it needs to disable `#[no_std]` for forwards-compatibility when an implementation is added.

I would appreciate a new crates.io release if you accept this :)
